### PR TITLE
Change null value handling

### DIFF
--- a/empoa-generator/src/main/java/org/openapitools/empoa/generator/swagger/SwGenerator.java
+++ b/empoa-generator/src/main/java/org/openapitools/empoa/generator/swagger/SwGenerator.java
@@ -103,7 +103,7 @@ public class SwGenerator {
             generateMember(sb, refMember, refSwMember, false);
         }
         if (mpElement.extensible) {
-            Member extensionsMember = new MapMember(null, "extensions", "Object", false, true, false);
+            Member extensionsMember = new MapMember(null, "extensions", "Object");
             SwMember extensionsSwMember = new SwMapMember(null, "extensions", "Object", false, true, false);
             generateMember(sb, extensionsMember, extensionsSwMember, false);
         }
@@ -309,36 +309,34 @@ public class SwGenerator {
         if (isMapMember) {
             MapMember mapMember = (MapMember) member;
             SwMapMember swMapMember = (SwMapMember) swMember;
-            if (mapMember.hasAdd) {
-                String itemVarName = StringUtil.decapitalize(StringUtil.computeSimpleName(mapMember.valueFqType));
-                sb.append("    @Override\n");
-                sb.append("    public " + simpleName + " " + mapMember.addName + "(String key, " + mapMember.valueFqType + " " + itemVarName + ") {\n");
-                if (isComplexType) {
-                    String valueName = "value";
-                    appendTypeCheck(sb, itemVarName, valueName, innerFqType, true, "        ");
-                    sb.append("        " + initName + "();\n");
-                    sb.append("        if (" + memberName + " == null) {\n");
-                    sb.append("            " + memberName + " = new " + java.util.LinkedHashMap.class.getCanonicalName() + "<>();\n");
-                    if (!isSingleMapMember) {
-                        sb.append("            " + swVarName + "." + swMapMember.setterName + "(new " + java.util.LinkedHashMap.class.getCanonicalName() + "<>());\n");
-                    }
-                    sb.append("        }\n");
-                    sb.append("        " + memberName + ".put(key, " + valueName + ");\n");
-                    sb.append("        " + swVarName + swGetter + ".put(key, " + valueName + ".getSw());\n");
-                    // sb.append(" " + swVarName + "." + swMapMember.addName + "(key, " + valueName + ".getSw());\n");
-                } else {
-                    String swAddName;
-                    if (isSingleMapMember) {
-                        swAddName = ".put";
-                    } else {
-                        swAddName = "." + swMapMember.addName;
-                    }
-                    sb.append("        " + swVarName + swAddName + "(key, " + itemVarName + ");\n");
+            String itemVarName = StringUtil.decapitalize(StringUtil.computeSimpleName(mapMember.valueFqType));
+            sb.append("    @Override\n");
+            sb.append("    public " + simpleName + " " + mapMember.addName + "(String key, " + mapMember.valueFqType + " " + itemVarName + ") {\n");
+            if (isComplexType) {
+                String valueName = "value";
+                appendTypeCheck(sb, itemVarName, valueName, innerFqType, true, "        ");
+                sb.append("        " + initName + "();\n");
+                sb.append("        if (" + memberName + " == null) {\n");
+                sb.append("            " + memberName + " = new " + java.util.LinkedHashMap.class.getCanonicalName() + "<>();\n");
+                if (!isSingleMapMember) {
+                    sb.append("            " + swVarName + "." + swMapMember.setterName + "(new " + java.util.LinkedHashMap.class.getCanonicalName() + "<>());\n");
                 }
-                sb.append("        return this;\n");
-                sb.append("    }\n");
-                sb.append("\n");
+                sb.append("        }\n");
+                sb.append("        " + memberName + ".put(key, " + valueName + ");\n");
+                sb.append("        " + swVarName + swGetter + ".put(key, " + valueName + ".getSw());\n");
+                // sb.append(" " + swVarName + "." + swMapMember.addName + "(key, " + valueName + ".getSw());\n");
+            } else {
+                String swAddName;
+                if (isSingleMapMember) {
+                    swAddName = ".put";
+                } else {
+                    swAddName = "." + swMapMember.addName;
+                }
+                sb.append("        " + swVarName + swAddName + "(key, " + itemVarName + ");\n");
             }
+            sb.append("        return this;\n");
+            sb.append("    }\n");
+            sb.append("\n");
             sb.append("    @Override\n");
             sb.append("    public void " + mapMember.removeName + "(String key) {\n");
             if (isComplexType) {

--- a/empoa-generator/src/main/java/org/openapitools/empoa/specs/MapMember.java
+++ b/empoa-generator/src/main/java/org/openapitools/empoa/specs/MapMember.java
@@ -21,36 +21,26 @@ public class MapMember extends Member {
 
     public final String valueFqType;
     public final String addName;
-    public final boolean hasAdd;
-    public final boolean addReturnsVoid;
     public final String removeName;
+    public MapNullValueStrategy nullValueStrategy;
 
     public MapMember(MemberType type, String name, String valueFqType) {
-        this(type, name, valueFqType, true);
+        this(type, name, valueFqType, MapNullValueStrategy.THROW_EXCEPTION);
     }
 
-    public MapMember(MemberType type, String name, String valueFqType, boolean hasBuilder) {
-        this(type, name, valueFqType, hasBuilder, true);
-    }
-
-    public MapMember(MemberType type, String name, String valueFqType, boolean hasBuilder, boolean hasAdd) {
-        this(type, name, valueFqType, hasBuilder, hasAdd, false);
-    }
-
-    public MapMember(MemberType type, String name, String valueFqType, boolean hasBuilder, boolean hasAdd, boolean addReturnsVoid) {
+    public MapMember(MemberType type, String name, String valueFqType, MapNullValueStrategy nullValueStrategy) {
         this(
-            type, name, valueFqType, "set" + StringUtil.capitalize(name), "get" + StringUtil.capitalize(name), StringUtil.decapitalize(name), "add" + StringUtil.capitalize(StringUtil.singular(name)), addReturnsVoid, hasAdd, hasBuilder,
-            "remove" + StringUtil.capitalize(StringUtil.singular(name))
+            type, name, valueFqType, "set" + StringUtil.capitalize(name), "get" + StringUtil.capitalize(name), StringUtil.decapitalize(name), "add" + StringUtil.capitalize(StringUtil.singular(name)),
+            "remove" + StringUtil.capitalize(StringUtil.singular(name)), nullValueStrategy
         );
     }
 
-    public MapMember(MemberType type, String name, String valueFqType, String setterName, String gettterName, String builderName, String addName, boolean addReturnsVoid, boolean hasAdd, boolean hasBuilder, String removeName) {
-        super(type, name, "java.util.Map<String, " + valueFqType + ">", setterName, gettterName, builderName, true, true, true, hasBuilder);
+    public MapMember(MemberType type, String name, String valueFqType, String setterName, String gettterName, String builderName, String addName, String removeName, MapNullValueStrategy nullValueStrategy) {
+        super(type, name, "java.util.Map<String, " + valueFqType + ">", setterName, gettterName, builderName, true, true, true, true);
         this.valueFqType = valueFqType;
         this.addName = addName;
-        this.hasAdd = hasAdd;
-        this.addReturnsVoid = addReturnsVoid;
         this.removeName = removeName;
+        this.nullValueStrategy = nullValueStrategy;
     }
 
 }

--- a/empoa-generator/src/main/java/org/openapitools/empoa/specs/MapNullValueStrategy.java
+++ b/empoa-generator/src/main/java/org/openapitools/empoa/specs/MapNullValueStrategy.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright 2019 Jeremie Bresson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+package org.openapitools.empoa.specs;
+
+public enum MapNullValueStrategy {
+    CONVERT_NULL_TO_EMPTY_LIST, NULL_ALLOWED, THROW_EXCEPTION
+
+}

--- a/empoa-generator/src/main/java/org/openapitools/empoa/specs/OpenAPISpec.java
+++ b/empoa-generator/src/main/java/org/openapitools/empoa/specs/OpenAPISpec.java
@@ -204,7 +204,7 @@ public class OpenAPISpec {
         members.add(new ListMember(MemberType.Operation_Parameters, "Parameters", Parameter.class.getCanonicalName()));
         members.add(new Member(MemberType.Operation_RequestBody, "RequestBody", RequestBody.class.getCanonicalName()));
         members.add(new Member(MemberType.Operation_Responses, "Responses", APIResponses.class.getCanonicalName()));
-        members.add(new MapMember(MemberType.Operation_Callbacks, "Callbacks", Callback.class.getCanonicalName(), true, true));
+        members.add(new MapMember(MemberType.Operation_Callbacks, "Callbacks", Callback.class.getCanonicalName()));
         members.add(new Member(MemberType.Operation_Deprecated, "Deprecated", Boolean.class.getSimpleName()));
         members.add(new ListMember(MemberType.Operation_Security, "Security", SecurityRequirement.class.getName(), "addSecurityRequirement", "removeSecurityRequirement"));
         members.add(new ListMember(MemberType.Operation_Servers, "Servers", Server.class.getCanonicalName()));
@@ -318,7 +318,7 @@ public class OpenAPISpec {
     public static Element createEncoding() {
         List<IMember> members = new ArrayList<>();
         members.add(new Member(MemberType.Encoding_ContentType, "ContentType", String.class.getSimpleName()));
-        members.add(new MapMember(MemberType.Encoding_Headers, "Headers", Header.class.getName(), true, true));
+        members.add(new MapMember(MemberType.Encoding_Headers, "Headers", Header.class.getName()));
         members.add(new Member(MemberType.Encoding_Style, "Style", Encoding.Style.class.getCanonicalName()));
         members.add(new Member(MemberType.Encoding_Explode, "Explode", Boolean.class.getSimpleName()));
         members.add(new Member(MemberType.Encoding_AllowReserved, "AllowReserved", Boolean.class.getSimpleName()));
@@ -450,13 +450,13 @@ public class OpenAPISpec {
 
     public static Element createScopes() {
         List<IMember> members = new ArrayList<>();
-        members.add(new MapMember(MemberType.Scopes_Scopes, "Scopes", String.class.getSimpleName()));
+        members.add(new MapMember(MemberType.Scopes_Scopes, "Scopes", String.class.getSimpleName(), MapNullValueStrategy.NULL_ALLOWED));
         return new Element(ElementType.Scopes, Scopes.class.getName(), true, false, members);
     }
 
     public static Element createSecurityRequirement() {
         List<IMember> members = new ArrayList<>();
-        members.add(new MapMember(MemberType.SecurityRequirement_Schemes, "Schemes", "java.util.List<String>"));
+        members.add(new MapMember(MemberType.SecurityRequirement_Schemes, "Schemes", "java.util.List<String>", MapNullValueStrategy.CONVERT_NULL_TO_EMPTY_LIST));
         members.add(new AdditionalMethod(Type.SecurityRequirement_addScheme_singleton));
         members.add(new AdditionalMethod(Type.SecurityRequirement_addScheme_empty));
         return new Element(ElementType.SecurityRequirement, SecurityRequirement.class.getName(), false, false, members);

--- a/empoa-generator/src/main/java/org/openapitools/empoa/specs/swagger/SwSpec.java
+++ b/empoa-generator/src/main/java/org/openapitools/empoa/specs/swagger/SwSpec.java
@@ -13,9 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  ******************************************************************************/
-/**
- *
- */
 package org.openapitools.empoa.specs.swagger;
 
 import java.math.BigDecimal;

--- a/empoa-simple-models-impl/src/main/java/org/openapitools/empoa/simple/internal/models/security/ScopesImpl.java
+++ b/empoa-simple-models-impl/src/main/java/org/openapitools/empoa/simple/internal/models/security/ScopesImpl.java
@@ -81,14 +81,10 @@ public class ScopesImpl implements Scopes {
 
     @Override
     public Scopes addScope(String key, String string) {
-        if (string == null) {
-            throw new IllegalArgumentException("Null value for key '" + key + "' is not allowed");
-        } else {
-            if (_scopes == null) {
-                _scopes = new java.util.LinkedHashMap<>();
-            }
-            _scopes.put(key, string);
+        if (_scopes == null) {
+            _scopes = new java.util.LinkedHashMap<>();
         }
+        _scopes.put(key, string);
         return this;
     }
 

--- a/empoa-simple-models-impl/src/main/java/org/openapitools/empoa/simple/internal/models/security/SecurityRequirementImpl.java
+++ b/empoa-simple-models-impl/src/main/java/org/openapitools/empoa/simple/internal/models/security/SecurityRequirementImpl.java
@@ -42,13 +42,12 @@ public class SecurityRequirementImpl implements SecurityRequirement {
     @Override
     public SecurityRequirement addScheme(String key, java.util.List<String> list) {
         if (list == null) {
-            throw new IllegalArgumentException("Null value for key '" + key + "' is not allowed");
-        } else {
-            if (_schemes == null) {
-                _schemes = new java.util.LinkedHashMap<>();
-            }
-            _schemes.put(key, list);
+            list = java.util.Collections.emptyList();
         }
+        if (_schemes == null) {
+            _schemes = new java.util.LinkedHashMap<>();
+        }
+        _schemes.put(key, list);
         return this;
     }
 

--- a/empoa-swagger-core/src/main/java/org/openapitools/empoa/swagger/core/internal/models/media/SwDiscriminator.java
+++ b/empoa-swagger-core/src/main/java/org/openapitools/empoa/swagger/core/internal/models/media/SwDiscriminator.java
@@ -68,7 +68,11 @@ public class SwDiscriminator implements Discriminator {
 
     @Override
     public Discriminator addMapping(String key, String string) {
-        _swDiscriminator.mapping(key, string);
+        if (string == null) {
+            throw new IllegalArgumentException("Null value for key '" + key + "' is not allowed");
+        } else {
+            _swDiscriminator.mapping(key, string);
+        }
         return this;
     }
 

--- a/empoa-swagger-core/src/main/java/org/openapitools/empoa/swagger/core/internal/models/security/SwSecurityRequirement.java
+++ b/empoa-swagger-core/src/main/java/org/openapitools/empoa/swagger/core/internal/models/security/SwSecurityRequirement.java
@@ -60,6 +60,9 @@ public class SwSecurityRequirement implements SecurityRequirement {
 
     @Override
     public SecurityRequirement addScheme(String key, java.util.List<String> list) {
+        if (list == null) {
+            list = java.util.Collections.emptyList();
+        }
         _swSecurityRequirement.put(key, list);
         return this;
     }
@@ -74,7 +77,9 @@ public class SwSecurityRequirement implements SecurityRequirement {
     @Override
     public SecurityRequirement addScheme(String key, String scope) {
         java.util.List<String> list = new java.util.ArrayList<>();
-        list.add(scope);
+        if (scope != null) {
+            list.add(scope);
+        }
         return addScheme(key, list);
     }
 


### PR DESCRIPTION
Introduced on the `1.x` branch of [Eclipse MicroProfile OpenAPI](https://github.com/eclipse/microprofile-open-api), the TCK now enforces a different behavior for `null` values. 

Model classes:
* `Scope`
* `SecurityRequirement`
* `Discriminator`

---
Also changed with this PR:
`MapMember` is simplified: the options `hasAdd` and `addReturnsVoid` are no longer needed with the `2.0` version of Eclipse MicroProfile OpenAPI.