### PR TITLE
Gson: fix 'default' attribute

### DIFF
--- a/empoa-extended-tck/src/main/java/org/openapitools/empoa/extended/tck/AbstractSerializerTest.java
+++ b/empoa-extended-tck/src/main/java/org/openapitools/empoa/extended/tck/AbstractSerializerTest.java
@@ -25,11 +25,6 @@ import org.junit.jupiter.api.Test;
 
 public abstract class AbstractSerializerTest extends AbstractSpecTest {
 
-    protected static final String PING_JSON = "/extended-tck/specs/ping.json";
-    protected static final String HELLO_JSON = "/extended-tck/specs/hello.json";
-    protected static final String TODOAPP_JSON = "/extended-tck/specs/todoapp.json";
-    protected static final String MULTIPLE_RESPONSES_JSON = "/extended-tck/specs/multiple-responses.json";
-    protected static final String REF_WITH_SIBLING_VALUES_EXPECTED_JSON = "/extended-tck/specs/ref-with-sibling-values-expected.json";
     protected static final String REF_WITH_SIBLING_VALUES_INPUT_JSON = "/extended-tck/specs/ref-with-sibling-values.json";
 
     @Test
@@ -39,38 +34,16 @@ public abstract class AbstractSerializerTest extends AbstractSpecTest {
 
     @Override
     protected void runTest(Specs spec) throws Exception {
-        OpenAPI openAPI = createOpenAPI(spec);
+        OpenAPI openAPI = getOpenAPISpec(spec);
         assertThat(openAPI).isNotNull();
 
-        String expected = readExpectedFromResource(spec);
+        String expected = readJsonSpec(spec);
         String json = convertToJson(openAPI);
 
         assertThatJson(json).isEqualTo(expected);
     }
 
     protected abstract String convertToJson(OpenAPI openAPI) throws IOException;
-
-    private String readExpectedFromResource(Specs spec) throws IOException {
-        String name = toExpectedResourceName(spec);
-        return read(getClass().getResourceAsStream(name));
-    }
-
-    private String toExpectedResourceName(Specs spec) {
-        switch (spec) {
-        case PING:
-            return PING_JSON;
-        case HELLO:
-            return HELLO_JSON;
-        case TODOAPP:
-            return TODOAPP_JSON;
-        case MULTIPLE_RESPONSES:
-            return MULTIPLE_RESPONSES_JSON;
-        case REF_WITH_SIBLING_VALUES:
-            return REF_WITH_SIBLING_VALUES_EXPECTED_JSON;
-        default:
-            throw new IllegalArgumentException("Unknown spec: " + spec);
-        }
-    }
 
     protected String readInputFromResource(Specs spec) throws IOException {
         String name = toInputResourceName(spec);
@@ -87,6 +60,8 @@ public abstract class AbstractSerializerTest extends AbstractSpecTest {
             return TODOAPP_JSON;
         case MULTIPLE_RESPONSES:
             return MULTIPLE_RESPONSES_JSON;
+        case BIG:
+            return BIG_JSON;
         case REF_WITH_SIBLING_VALUES:
             return REF_WITH_SIBLING_VALUES_INPUT_JSON;
         default:

--- a/empoa-extended-tck/src/main/java/org/openapitools/empoa/extended/tck/AbstractSpecTest.java
+++ b/empoa-extended-tck/src/main/java/org/openapitools/empoa/extended/tck/AbstractSpecTest.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.junit.jupiter.api.Test;
+import org.openapitools.empoa.extended.tck.specs.BigSpec;
 import org.openapitools.empoa.extended.tck.specs.HelloSpec;
 import org.openapitools.empoa.extended.tck.specs.MultipleResponsesSpec;
 import org.openapitools.empoa.extended.tck.specs.PingSpec;
@@ -36,8 +37,16 @@ public abstract class AbstractSpecTest {
         HELLO,
         TODOAPP,
         MULTIPLE_RESPONSES,
+        BIG,
         REF_WITH_SIBLING_VALUES
     }
+
+    protected static final String PING_JSON = "/extended-tck/specs/ping.json";
+    protected static final String HELLO_JSON = "/extended-tck/specs/hello.json";
+    protected static final String TODOAPP_JSON = "/extended-tck/specs/todoapp.json";
+    protected static final String MULTIPLE_RESPONSES_JSON = "/extended-tck/specs/multiple-responses.json";
+    protected static final String BIG_JSON = "/extended-tck/specs/big.json";
+    protected static final String REF_WITH_SIBLING_VALUES_EXPECTED_JSON = "/extended-tck/specs/ref-with-sibling-values-expected.json";
 
     @Test
     public void testPingSpec() throws Exception {
@@ -59,9 +68,14 @@ public abstract class AbstractSpecTest {
         runTest(Specs.MULTIPLE_RESPONSES);
     }
 
+    @Test
+    public void testBigSpec() throws Exception {
+        runTest(Specs.BIG);
+    }
+
     protected abstract void runTest(Specs spec) throws Exception;
 
-    protected OpenAPI createOpenAPI(Specs spec) throws IOException {
+    protected OpenAPI getOpenAPISpec(Specs spec) throws IOException {
         switch (spec) {
         case PING:
             return PingSpec.create();
@@ -71,8 +85,34 @@ public abstract class AbstractSpecTest {
             return TodoappSpec.create();
         case MULTIPLE_RESPONSES:
             return MultipleResponsesSpec.create();
+        case BIG:
+            return BigSpec.create();
         case REF_WITH_SIBLING_VALUES:
             return RefWithSiblingValuesSpec.create();
+        default:
+            throw new IllegalArgumentException("Unknown spec: " + spec);
+        }
+    }
+
+    protected String readJsonSpec(Specs spec) throws IOException {
+        String name = toJsonSpecName(spec);
+        return read(getClass().getResourceAsStream(name));
+    }
+
+    private String toJsonSpecName(Specs spec) {
+        switch (spec) {
+        case PING:
+            return PING_JSON;
+        case HELLO:
+            return HELLO_JSON;
+        case TODOAPP:
+            return TODOAPP_JSON;
+        case MULTIPLE_RESPONSES:
+            return MULTIPLE_RESPONSES_JSON;
+        case BIG:
+            return BIG_JSON;
+        case REF_WITH_SIBLING_VALUES:
+            return REF_WITH_SIBLING_VALUES_EXPECTED_JSON;
         default:
             throw new IllegalArgumentException("Unknown spec: " + spec);
         }

--- a/empoa-extended-tck/src/main/java/org/openapitools/empoa/extended/tck/specs/BigSpec.java
+++ b/empoa-extended-tck/src/main/java/org/openapitools/empoa/extended/tck/specs/BigSpec.java
@@ -1,0 +1,579 @@
+/*******************************************************************************
+ * Copyright 2019 Jeremie Bresson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+package org.openapitools.empoa.extended.tck.specs;
+
+import static org.eclipse.microprofile.openapi.OASFactory.*;
+
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.media.Schema;
+import org.eclipse.microprofile.openapi.models.parameters.Parameter;
+import org.eclipse.microprofile.openapi.models.security.SecurityScheme;
+
+public final class BigSpec {
+    public static OpenAPI create() {
+        return createOpenAPI()
+            .openapi("3.0.1")
+            .info(
+                createInfo()
+                    .title("Big Specification")
+                    .description("This specification description")
+                    .termsOfService("http://example.com/terms/")
+                    .contact(
+                        createContact()
+                            .name("Support")
+                            .url("http://www.example.com/support/")
+                            .email("support@example.com")
+                    )
+                    .license(
+                        createLicense()
+                            .name("Apache 2.0")
+                            .url("https://www.apache.org/licenses/LICENSE-2.0.html")
+                    )
+                    .version("1.0")
+            )
+            .addServer(
+                createServer()
+                    .url("http://api.example.com/")
+                    .description("Main server")
+            )
+            .addServer(
+                createServer()
+                    .url("http://{version}.example-test.com:8080/{username}/")
+                    .description("Test server")
+                    .variables(
+                        createServerVariables()
+                            .addServerVariable(
+                                "version", createServerVariable()
+                                    .addEnumeration("v1")
+                                    .addEnumeration("v2")
+                                    .addEnumeration("v3")
+                                    .defaultValue("v1")
+                            )
+                            .addServerVariable(
+                                "username", createServerVariable()
+                                    .defaultValue("alice")
+                                    .description("the developer username")
+                            )
+                    )
+            )
+            .addTag(
+                createTag()
+                    .name("WIP")
+                    .description("work-in-progress")
+            )
+            .paths(
+                createPaths()
+                    .addPathItem(
+                        "/tree/{name}", createPathItem()
+                            .GET(
+                                createOperation()
+                                    .addTag("WIP")
+                                    .summary("Return a tree of nodes")
+                                    .operationId("tree")
+                                    .addParameter(
+                                        createParameter()
+                                            .name("name")
+                                            .in(Parameter.In.PATH)
+                                            .required(true)
+                                            .schema(
+                                                createSchema()
+                                                    .type(Schema.SchemaType.STRING)
+                                            )
+                                    )
+                                    .responses(
+                                        createAPIResponses()
+                                            .addAPIResponse(
+                                                "200", createAPIResponse()
+                                                    .description("OK")
+                                                    .content(
+                                                        createContent()
+                                                            .addMediaType(
+                                                                "application/text", createMediaType()
+                                                                    .schema(
+                                                                        createSchema()
+                                                                            .type(Schema.SchemaType.STRING)
+                                                                    )
+                                                            )
+                                                            .addMediaType(
+                                                                "application/json", createMediaType()
+                                                                    .schema(
+                                                                        createSchema()
+                                                                            .ref("#/components/schemas/Node")
+                                                                    )
+                                                            )
+                                                    )
+                                            )
+                                            .addAPIResponse(
+                                                "4XX", createAPIResponse()
+                                                    .description("Error")
+                                                    .content(
+                                                        createContent()
+                                                            .addMediaType(
+                                                                "*/*", createMediaType()
+                                                                    .schema(
+                                                                        createSchema()
+                                                                            .ref("#/components/schemas/Error")
+                                                                    )
+                                                            )
+                                                    )
+                                            )
+                                    )
+                                    .addSecurityRequirement(
+                                        createSecurityRequirement()
+                                            .addScheme("basic-auth")
+                                    )
+                                    .addSecurityRequirement(
+                                        createSecurityRequirement()
+                                            .addScheme("api-key-auth")
+                                    )
+                            )
+                    )
+                    .addPathItem(
+                        "/messages", createPathItem()
+                            .POST(
+                                createOperation()
+                                    .summary("Create a message")
+                                    .operationId("postMessage")
+                                    .requestBody(
+                                        createRequestBody()
+                                            .content(
+                                                createContent()
+                                                    .addMediaType(
+                                                        "application/json", createMediaType()
+                                                            .schema(
+                                                                createSchema()
+                                                                    .type(Schema.SchemaType.OBJECT)
+                                                                    .addProperty(
+                                                                        "id", createSchema()
+                                                                            .type(Schema.SchemaType.INTEGER)
+                                                                            .format("int32")
+                                                                    )
+                                                                    .addProperty(
+                                                                        "description", createSchema()
+                                                                            .type(Schema.SchemaType.STRING)
+                                                                    )
+                                                                    .addProperty(
+                                                                        "language", createSchema()
+                                                                            .defaultValue("EN")
+                                                                            .addEnumeration("EN")
+                                                                            .addEnumeration("FR")
+                                                                            .addEnumeration("DE")
+                                                                            .addEnumeration("IT")
+                                                                            .type(Schema.SchemaType.STRING)
+                                                                    )
+                                                            )
+                                                    )
+                                            )
+                                    )
+                                    .responses(
+                                        createAPIResponses()
+                                            .addAPIResponse(
+                                                "200", createAPIResponse()
+                                                    .ref("#/components/responses/MessageResponse")
+                                            )
+                                    )
+                            )
+                    )
+                    .addPathItem(
+                        "/messages/{id}", createPathItem()
+                            .GET(
+                                createOperation()
+                                    .summary("Return a message")
+                                    .operationId("getMessage")
+                                    .addParameter(
+                                        createParameter()
+                                            .ref("#/components/parameters/LanguageParam")
+                                    )
+                                    .responses(
+                                        createAPIResponses()
+                                            .addAPIResponse(
+                                                "200", createAPIResponse()
+                                                    .ref("#/components/responses/MessageResponse")
+                                            )
+                                    )
+                            )
+                            .PUT(
+                                createOperation()
+                                    .summary("Update a message")
+                                    .operationId("putMessage")
+                                    .addParameter(
+                                        createParameter()
+                                            .name("force")
+                                            .in(Parameter.In.QUERY)
+                                            .schema(
+                                                createSchema()
+                                                    .type(Schema.SchemaType.BOOLEAN)
+                                            )
+                                    )
+                                    .requestBody(
+                                        createRequestBody()
+                                            .ref("#/components/requestBodies/UpdateBody")
+                                    )
+                                    .responses(
+                                        createAPIResponses()
+                                            .addAPIResponse(
+                                                "200", createAPIResponse()
+                                                    .ref("#/components/responses/MessageResponse")
+                                            )
+                                    )
+                            )
+                            .addParameter(
+                                createParameter()
+                                    .name("id")
+                                    .in(Parameter.In.PATH)
+                                    .required(true)
+                                    .schema(
+                                        createSchema()
+                                            .type(Schema.SchemaType.STRING)
+                                    )
+                            )
+                    )
+                    .addPathItem(
+                        "/subscribe", createPathItem()
+                            .POST(
+                                createOperation()
+                                    .summary("Subscribe to a webhook")
+                                    .operationId("subscribeWebhook")
+                                    .requestBody(
+                                        createRequestBody()
+                                            .content(
+                                                createContent()
+                                                    .addMediaType(
+                                                        "application/json", createMediaType()
+                                                            .schema(
+                                                                createSchema()
+                                                                    .ref("#/components/schemas/Body")
+                                                            )
+                                                    )
+                                            )
+                                            .required(true)
+                                    )
+                                    .responses(
+                                        createAPIResponses()
+                                            .addAPIResponse(
+                                                "201", createAPIResponse()
+                                                    .description("Webhook created")
+                                            )
+                                    )
+                                    .addCallback(
+                                        "myEvent", createCallback()
+                                            .addPathItem(
+                                                "{$request.body#/callbackUrl}", createPathItem()
+                                                    .POST(
+                                                        createOperation()
+                                                            .requestBody(
+                                                                createRequestBody()
+                                                                    .content(
+                                                                        createContent()
+                                                                            .addMediaType(
+                                                                                "application/json", createMediaType()
+                                                                                    .schema(
+                                                                                        createSchema()
+                                                                                            .addRequired("message")
+                                                                                            .type(Schema.SchemaType.OBJECT)
+                                                                                            .addProperty(
+                                                                                                "message", createSchema()
+                                                                                                    .type(Schema.SchemaType.STRING)
+                                                                                                    .example("Some event happened")
+                                                                                            )
+                                                                                    )
+                                                                            )
+                                                                    )
+                                                                    .required(true)
+                                                            )
+                                                            .responses(
+                                                                createAPIResponses()
+                                                                    .addAPIResponse(
+                                                                        "200", createAPIResponse()
+                                                                            .description("Your server returns this code if it accepts the callback")
+                                                                    )
+                                                            )
+                                                    )
+                                            )
+                                    )
+                                    .addCallback(
+                                        "pingEvent", createCallback()
+                                            .ref("#/components/callbacks/PingCallback")
+                                    )
+                            )
+                    )
+            )
+            .components(
+                createComponents()
+                    .addSchema(
+                        "Message", createSchema()
+                            .type(Schema.SchemaType.OBJECT)
+                            .addProperty(
+                                "value", createSchema()
+                                    .type(Schema.SchemaType.STRING)
+                            )
+                            .addProperty(
+                                "description", createSchema()
+                                    .type(Schema.SchemaType.STRING)
+                            )
+                    )
+                    .addSchema(
+                        "Node", createSchema()
+                            .type(Schema.SchemaType.OBJECT)
+                            .addProperty(
+                                "name", createSchema()
+                                    .type(Schema.SchemaType.STRING)
+                            )
+                            .addProperty(
+                                "children", createSchema()
+                                    .type(Schema.SchemaType.ARRAY)
+                                    .items(
+                                        createSchema()
+                                            .ref("#/components/schemas/Node")
+                                    )
+                            )
+                    )
+                    .addSchema(
+                        "Error", createSchema()
+                            .type(Schema.SchemaType.OBJECT)
+                            .addProperty(
+                                "code", createSchema()
+                                    .type(Schema.SchemaType.INTEGER)
+                                    .format("int32")
+                            )
+                            .addProperty(
+                                "message", createSchema()
+                                    .type(Schema.SchemaType.STRING)
+                            )
+                    )
+                    .addSchema(
+                        "Body", createSchema()
+                            .addRequired("callbackUrl")
+                            .type(Schema.SchemaType.OBJECT)
+                            .addProperty(
+                                "callbackUrl", createSchema()
+                                    .type(Schema.SchemaType.STRING)
+                                    .format("uri")
+                                    .example("https://myserver.com/send/callback/here")
+                            )
+                            .addProperty(
+                                "items", createSchema()
+                                    .type(Schema.SchemaType.ARRAY)
+                                    .items(
+                                        createSchema()
+                                            .ref("#/components/schemas/Info")
+                                    )
+                            )
+                    )
+                    .addSchema(
+                        "Info", createSchema()
+                            .discriminator(
+                                createDiscriminator()
+                                    .propertyName("infoType")
+                                    .addMapping("simple", "#/components/schemas/SimpleInfo")
+                                    .addMapping("extended", "#/components/schemas/ExtendedInfo")
+                            )
+                            .type(Schema.SchemaType.OBJECT)
+                            .addOneOf(
+                                createSchema()
+                                    .ref("#/components/schemas/SimpleInfo")
+                            )
+                            .addOneOf(
+                                createSchema()
+                                    .ref("#/components/schemas/ExtendedInfo")
+                            )
+                    )
+                    .addSchema(
+                        "SimpleInfo", createSchema()
+                            .type(Schema.SchemaType.OBJECT)
+                            .addProperty(
+                                "infoType", createSchema()
+                                    .type(Schema.SchemaType.STRING)
+                            )
+                            .addProperty(
+                                "description", createSchema()
+                                    .type(Schema.SchemaType.STRING)
+                            )
+                    )
+                    .addSchema(
+                        "ExtendedInfo", createSchema()
+                            .type(Schema.SchemaType.OBJECT)
+                            .addProperty(
+                                "infoType", createSchema()
+                                    .type(Schema.SchemaType.STRING)
+                            )
+                            .addProperty(
+                                "code", createSchema()
+                                    .type(Schema.SchemaType.INTEGER)
+                                    .format("int32")
+                            )
+                            .addProperty(
+                                "data", createSchema()
+                                    .type(Schema.SchemaType.OBJECT)
+                                    .not(
+                                        createSchema()
+                                            .type(Schema.SchemaType.INTEGER)
+                                    )
+                            )
+                            .addProperty(
+                                "info", createSchema()
+                                    .type(Schema.SchemaType.STRING)
+                            )
+                    )
+                    .addSchema(
+                        "RootClass", createSchema()
+                            .discriminator(
+                                createDiscriminator()
+                                    .propertyName("type")
+                            )
+                            .addRequired("type")
+                            .type(Schema.SchemaType.OBJECT)
+                            .addProperty(
+                                "type", createSchema()
+                                    .type(Schema.SchemaType.STRING)
+                            )
+                            .addProperty(
+                                "prop0", createSchema()
+                                    .type(Schema.SchemaType.STRING)
+                            )
+                    )
+                    .addSchema(
+                        "ParentObject", createSchema()
+                            .addAllOf(
+                                createSchema()
+                                    .ref("#/components/schemas/RootClass")
+                            )
+                            .addAllOf(
+                                createSchema()
+                                    .type(Schema.SchemaType.OBJECT)
+                                    .addProperty(
+                                        "prop1", createSchema()
+                                            .type(Schema.SchemaType.STRING)
+                                    )
+                                    .addProperty(
+                                        "prop2", createSchema()
+                                            .type(Schema.SchemaType.STRING)
+                                    )
+                            )
+                    )
+                    .addSchema(
+                        "ChildObject", createSchema()
+                            .addAllOf(
+                                createSchema()
+                                    .ref("#/components/schemas/ParentObject")
+                            )
+                            .addAllOf(
+                                createSchema()
+                                    .type(Schema.SchemaType.OBJECT)
+                                    .addProperty(
+                                        "prop3", createSchema()
+                                            .type(Schema.SchemaType.STRING)
+                                    )
+                                    .addProperty(
+                                        "prop4", createSchema()
+                                            .type(Schema.SchemaType.STRING)
+                                    )
+                            )
+                    )
+                    .addResponse(
+                        "MessageResponse", createAPIResponse()
+                            .description("OK")
+                            .content(
+                                createContent()
+                                    .addMediaType(
+                                        "*/*", createMediaType()
+                                            .schema(
+                                                createSchema()
+                                                    .ref("#/components/schemas/Message")
+                                            )
+                                    )
+                            )
+                    )
+                    .addParameter(
+                        "LanguageParam", createParameter()
+                            .name("language")
+                            .in(Parameter.In.QUERY)
+                            .description("Language of the message")
+                            .schema(
+                                createSchema()
+                                    .addEnumeration("english")
+                                    .addEnumeration("french")
+                                    .addEnumeration("german")
+                                    .addEnumeration("italian")
+                                    .type(Schema.SchemaType.STRING)
+                            )
+                    )
+                    .addRequestBody(
+                        "UpdateBody", createRequestBody()
+                            .content(
+                                createContent()
+                                    .addMediaType(
+                                        "application/json", createMediaType()
+                                            .schema(
+                                                createSchema()
+                                                    .type(Schema.SchemaType.OBJECT)
+                                                    .addProperty(
+                                                        "message", createSchema()
+                                                            .type(Schema.SchemaType.STRING)
+                                                    )
+                                                    .addProperty(
+                                                        "description", createSchema()
+                                                            .type(Schema.SchemaType.STRING)
+                                                    )
+                                            )
+                                    )
+                            )
+                    )
+                    .addSecurityScheme(
+                        "basic-auth", createSecurityScheme()
+                            .type(SecurityScheme.Type.HTTP)
+                            .description("Login and password")
+                            .scheme("basic")
+                    )
+                    .addSecurityScheme(
+                        "api-key-auth", createSecurityScheme()
+                            .type(SecurityScheme.Type.APIKEY)
+                            .name("X-ACCESS-API-KEY")
+                            .in(SecurityScheme.In.HEADER)
+                            .scheme("basic")
+                    )
+                    .addCallback(
+                        "PingCallback", createCallback()
+                            .addPathItem(
+                                "{$request.body#/callbackUrl}", createPathItem()
+                                    .GET(
+                                        createOperation()
+                                            .addParameter(
+                                                createParameter()
+                                                    .name("x-callback-id")
+                                                    .in(Parameter.In.HEADER)
+                                                    .description("id")
+                                                    .required(true)
+                                                    .style(Parameter.Style.SIMPLE)
+                                                    .explode(false)
+                                                    .schema(
+                                                        createSchema()
+                                                            .type(Schema.SchemaType.STRING)
+                                                    )
+                                            )
+                                            .responses(
+                                                createAPIResponses()
+                                                    .addAPIResponse(
+                                                        "200", createAPIResponse()
+                                                            .description("Your server returns this code if it accepts the callback")
+                                                    )
+                                            )
+                                    )
+                            )
+                    )
+            );
+    }
+}

--- a/empoa-extended-tck/src/main/resources/extended-tck/specs/big.json
+++ b/empoa-extended-tck/src/main/resources/extended-tck/specs/big.json
@@ -1,0 +1,495 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Big Specification",
+    "description": "This specification description",
+    "termsOfService": "http://example.com/terms/",
+    "contact": {
+      "name": "Support",
+      "url": "http://www.example.com/support/",
+      "email": "support@example.com"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+    },
+    "version": "1.0"
+  },
+  "servers": [
+    {
+      "url": "http://api.example.com/",
+      "description": "Main server"
+    },
+    {
+      "url": "http://{version}.example-test.com:8080/{username}/",
+      "description": "Test server",
+      "variables": {
+        "version": {
+          "enum": [
+            "v1",
+            "v2",
+            "v3"
+          ],
+          "default": "v1"
+        },
+        "username": {
+          "default": "alice",
+          "description": "the developer username"
+        }
+      }
+    }
+  ],
+  "tags": [
+    {
+      "name": "WIP",
+      "description": "work-in-progress"
+    }
+  ],
+  "paths": {
+    "/tree/{name}": {
+      "get": {
+        "tags": [
+          "WIP"
+        ],
+        "summary": "Return a tree of nodes",
+        "operationId": "tree",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/text": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Node"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Error",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basic-auth": []
+          },
+          {
+            "api-key-auth": []
+          }
+        ]
+      }
+    },
+    "/messages": {
+      "post": {
+        "summary": "Create a message",
+        "operationId": "postMessage",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "language": {
+                    "type": "string",
+                    "default": "EN",
+                    "enum": [
+                      "EN",
+                      "FR",
+                      "DE",
+                      "IT"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/MessageResponse"
+          }
+        }
+      }
+    },
+    "/messages/{id}": {
+      "get": {
+        "summary": "Return a message",
+        "operationId": "getMessage",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/LanguageParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/MessageResponse"
+          }
+        }
+      },
+      "put": {
+        "summary": "Update a message",
+        "operationId": "putMessage",
+        "parameters": [
+          {
+            "name": "force",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/UpdateBody"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/MessageResponse"
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/subscribe": {
+      "post": {
+        "summary": "Subscribe to a webhook",
+        "operationId": "subscribeWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Body"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Webhook created"
+          }
+        },
+        "callbacks": {
+          "myEvent": {
+            "{$request.body#/callbackUrl}": {
+              "post": {
+                "requestBody": {
+                  "content": {
+                    "application/json": {
+                      "schema": {
+                        "type": "object",
+                        "required": [
+                          "message"
+                        ],
+                        "properties": {
+                          "message": {
+                            "type": "string",
+                            "example": "Some event happened"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "required": true
+                },
+                "responses": {
+                  "200": {
+                    "description": "Your server returns this code if it accepts the callback"
+                  }
+                }
+              }
+            }
+          },
+          "pingEvent": {
+            "$ref": "#/components/callbacks/PingCallback"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Message": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        }
+      },
+      "Node": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "children": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Node"
+            }
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      },
+      "Body": {
+        "type": "object",
+        "required": [
+          "callbackUrl"
+        ],
+        "properties": {
+          "callbackUrl": {
+            "type": "string",
+            "format": "uri",
+            "example": "https://myserver.com/send/callback/here"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Info"
+            }
+          }
+        }
+      },
+      "Info": {
+        "type": "object",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/SimpleInfo"
+          },
+          {
+            "$ref": "#/components/schemas/ExtendedInfo"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "infoType",
+          "mapping": {
+            "simple": "#/components/schemas/SimpleInfo",
+            "extended": "#/components/schemas/ExtendedInfo"
+          }
+        }
+      },
+      "SimpleInfo": {
+        "type": "object",
+        "properties": {
+          "infoType": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        }
+      },
+      "ExtendedInfo": {
+        "type": "object",
+        "properties": {
+          "infoType": {
+            "type": "string"
+          },
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "data": {
+            "type": "object",
+            "not": {
+              "type": "integer"
+            }
+          },
+          "info": {
+            "type": "string"
+          }
+        }
+      },
+      "RootClass": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "prop0": {
+            "type": "string"
+          }
+        },
+        "discriminator": {
+          "propertyName": "type"
+        }
+      },
+      "ParentObject": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RootClass"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "prop1": {
+                "type": "string"
+              },
+              "prop2": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "ChildObject": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ParentObject"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "prop3": {
+                "type": "string"
+              },
+              "prop4": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "responses": {
+      "MessageResponse": {
+        "description": "OK",
+        "content": {
+          "*/*": {
+            "schema": {
+              "$ref": "#/components/schemas/Message"
+            }
+          }
+        }
+      }
+    },
+    "parameters": {
+      "LanguageParam": {
+        "name": "language",
+        "in": "query",
+        "description": "Language of the message",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "english",
+            "french",
+            "german",
+            "italian"
+          ]
+        }
+      }
+    },
+    "requestBodies": {
+      "UpdateBody": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "basic-auth": {
+        "type": "http",
+        "description": "Login and password",
+        "scheme": "basic"
+      },
+      "api-key-auth": {
+        "type": "apiKey",
+        "name": "X-ACCESS-API-KEY",
+        "in": "header",
+        "scheme": "basic"
+      }
+    },
+    "callbacks": {
+      "PingCallback": {
+        "{$request.body#/callbackUrl}": {
+          "get": {
+            "parameters": [
+              {
+                "name": "x-callback-id",
+                "in": "header",
+                "description": "id",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                },
+                "style": "simple",
+                "explode": false
+              }
+            ],
+            "responses": {
+              "200": {
+                "description": "Your server returns this code if it accepts the callback"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/empoa-generator/src/main/java/org/openapitools/empoa/util/StringUtil.java
+++ b/empoa-generator/src/main/java/org/openapitools/empoa/util/StringUtil.java
@@ -29,6 +29,12 @@ public class StringUtil {
         if (string == null || string.isEmpty()) {
             return string;
         }
+        if (string.startsWith("API")) {
+            return "api" + string.substring(3);
+        }
+        if (string.startsWith("XML")) {
+            return "xml" + string.substring(3);
+        }
         return string.substring(0, 1)
             .toLowerCase() + string.substring(1);
     }

--- a/empoa-gson-serializer/src/main/java/org/openapitools/empoa/gson/intermal/serializers/media/SchemaSerializer.java
+++ b/empoa-gson-serializer/src/main/java/org/openapitools/empoa/gson/intermal/serializers/media/SchemaSerializer.java
@@ -54,7 +54,7 @@ public class SchemaSerializer implements JsonSerializer<Schema> {
                 object.add("discriminator", context.serialize(src.getDiscriminator()));
             }
             if (src.getDefaultValue() != null) {
-                object.add("defaultValue", context.serialize(src.getDefaultValue()));
+                object.add("default", context.serialize(src.getDefaultValue()));
             }
             if (src.getEnumeration() != null) {
                 object.add("enum", context.serialize(src.getEnumeration()));

--- a/empoa-gson-serializer/src/main/java/org/openapitools/empoa/gson/intermal/serializers/servers/ServerVariableSerializer.java
+++ b/empoa-gson-serializer/src/main/java/org/openapitools/empoa/gson/intermal/serializers/servers/ServerVariableSerializer.java
@@ -33,7 +33,7 @@ public class ServerVariableSerializer implements JsonSerializer<ServerVariable> 
             object.add("enum", context.serialize(src.getEnumeration()));
         }
         if (src.getDefaultValue() != null) {
-            object.add("defaultValue", context.serialize(src.getDefaultValue()));
+            object.add("default", context.serialize(src.getDefaultValue()));
         }
         if (src.getDescription() != null) {
             object.add("description", context.serialize(src.getDescription()));

--- a/empoa-jackson-serializer/src/test/java/org/openapitools/empoa/jackson/OpenAPISerializerToYamlTest.java
+++ b/empoa-jackson-serializer/src/test/java/org/openapitools/empoa/jackson/OpenAPISerializerToYamlTest.java
@@ -24,7 +24,7 @@ public class OpenAPISerializerToYamlTest extends AbstractSpecTest {
 
     @Override
     protected void runTest(Specs spec) throws Exception {
-        OpenAPI openAPI = createOpenAPI(spec);
+        OpenAPI openAPI = getOpenAPISpec(spec);
         assertThat(openAPI).isNotNull();
 
         String expected = readFromResource(toResourceName(spec));
@@ -43,6 +43,8 @@ public class OpenAPISerializerToYamlTest extends AbstractSpecTest {
             return "/jackson-serializer/yaml/todoapp.yaml";
         case MULTIPLE_RESPONSES:
             return "/jackson-serializer/yaml/multiple-responses.yaml";
+        case BIG:
+            return "/jackson-serializer/yaml/big.yaml";
         default:
             throw new IllegalArgumentException("Unknown spec: " + spec);
         }

--- a/empoa-jackson-serializer/src/test/resources/jackson-serializer/yaml/big.yaml
+++ b/empoa-jackson-serializer/src/test/resources/jackson-serializer/yaml/big.yaml
@@ -1,0 +1,307 @@
+---
+openapi: 3.0.1
+info:
+  title: Big Specification
+  description: This specification description
+  termsOfService: http://example.com/terms/
+  contact:
+    name: Support
+    url: http://www.example.com/support/
+    email: support@example.com
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+  version: "1.0"
+servers:
+- url: http://api.example.com/
+  description: Main server
+- url: http://{version}.example-test.com:8080/{username}/
+  description: Test server
+  variables:
+    version:
+      default: v1
+      enum:
+      - v1
+      - v2
+      - v3
+    username:
+      default: alice
+      description: the developer username
+tags:
+- name: WIP
+  description: work-in-progress
+paths:
+  /tree/{name}:
+    get:
+      tags:
+      - WIP
+      summary: Return a tree of nodes
+      operationId: tree
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        200:
+          description: OK
+          content:
+            application/text:
+              schema:
+                type: string
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Node'
+        4XX:
+          description: Error
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+      - basic-auth: []
+      - api-key-auth: []
+  /messages:
+    post:
+      summary: Create a message
+      operationId: postMessage
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: integer
+                  format: int32
+                description:
+                  type: string
+                language:
+                  type: string
+                  default: EN
+                  enum:
+                  - EN
+                  - FR
+                  - DE
+                  - IT
+      responses:
+        200:
+          $ref: '#/components/responses/MessageResponse'
+  /messages/{id}:
+    get:
+      summary: Return a message
+      operationId: getMessage
+      parameters:
+      - $ref: '#/components/parameters/LanguageParam'
+      responses:
+        200:
+          $ref: '#/components/responses/MessageResponse'
+    put:
+      summary: Update a message
+      operationId: putMessage
+      parameters:
+      - name: force
+        in: query
+        schema:
+          type: boolean
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateBody'
+      responses:
+        200:
+          $ref: '#/components/responses/MessageResponse'
+    parameters:
+    - name: id
+      in: path
+      required: true
+      schema:
+        type: string
+  /subscribe:
+    post:
+      summary: Subscribe to a webhook
+      operationId: subscribeWebhook
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Body'
+        required: true
+      responses:
+        201:
+          description: Webhook created
+      callbacks:
+        myEvent:
+          '{$request.body#/callbackUrl}':
+            post:
+              requestBody:
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      required:
+                      - message
+                      properties:
+                        message:
+                          type: string
+                          example: Some event happened
+                required: true
+              responses:
+                200:
+                  description: Your server returns this code if it accepts the callback
+        pingEvent:
+          $ref: '#/components/callbacks/PingCallback'
+components:
+  schemas:
+    Message:
+      type: object
+      properties:
+        value:
+          type: string
+        description:
+          type: string
+    Node:
+      type: object
+      properties:
+        name:
+          type: string
+        children:
+          type: array
+          items:
+            $ref: '#/components/schemas/Node'
+    Error:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+    Body:
+      type: object
+      required:
+      - callbackUrl
+      properties:
+        callbackUrl:
+          type: string
+          format: uri
+          example: https://myserver.com/send/callback/here
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/Info'
+    Info:
+      type: object
+      oneOf:
+      - $ref: '#/components/schemas/SimpleInfo'
+      - $ref: '#/components/schemas/ExtendedInfo'
+      discriminator:
+        propertyName: infoType
+        mapping:
+          simple: '#/components/schemas/SimpleInfo'
+          extended: '#/components/schemas/ExtendedInfo'
+    SimpleInfo:
+      type: object
+      properties:
+        infoType:
+          type: string
+        description:
+          type: string
+    ExtendedInfo:
+      type: object
+      properties:
+        infoType:
+          type: string
+        code:
+          type: integer
+          format: int32
+        data:
+          type: object
+          not:
+            type: integer
+        info:
+          type: string
+    RootClass:
+      type: object
+      required:
+      - type
+      properties:
+        type:
+          type: string
+        prop0:
+          type: string
+      discriminator:
+        propertyName: type
+    ParentObject:
+      allOf:
+      - $ref: '#/components/schemas/RootClass'
+      - type: object
+        properties:
+          prop1:
+            type: string
+          prop2:
+            type: string
+    ChildObject:
+      allOf:
+      - $ref: '#/components/schemas/ParentObject'
+      - type: object
+        properties:
+          prop3:
+            type: string
+          prop4:
+            type: string
+  responses:
+    MessageResponse:
+      description: OK
+      content:
+        '*/*':
+          schema:
+            $ref: '#/components/schemas/Message'
+  parameters:
+    LanguageParam:
+      name: language
+      in: query
+      description: Language of the message
+      schema:
+        type: string
+        enum:
+        - english
+        - french
+        - german
+        - italian
+  requestBodies:
+    UpdateBody:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+              description:
+                type: string
+  securitySchemes:
+    basic-auth:
+      type: http
+      description: Login and password
+      scheme: basic
+    api-key-auth:
+      type: apiKey
+      name: X-ACCESS-API-KEY
+      in: header
+      scheme: basic
+  callbacks:
+    PingCallback:
+      '{$request.body#/callbackUrl}':
+        get:
+          parameters:
+          - name: x-callback-id
+            in: header
+            description: id
+            required: true
+            schema:
+              type: string
+            style: simple
+            explode: false
+          responses:
+            200:
+              description: Your server returns this code if it accepts the callback

--- a/empoa-javapoet/src/test/java/org/openapitools/empoa/javapoet/JavaFileConverterTest.java
+++ b/empoa-javapoet/src/test/java/org/openapitools/empoa/javapoet/JavaFileConverterTest.java
@@ -22,6 +22,7 @@ import java.nio.file.Paths;
 import org.assertj.core.api.Assertions;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.openapitools.empoa.extended.tck.AbstractSpecTest;
+import org.openapitools.empoa.extended.tck.specs.BigSpec;
 import org.openapitools.empoa.extended.tck.specs.HelloSpec;
 import org.openapitools.empoa.extended.tck.specs.MultipleResponsesSpec;
 import org.openapitools.empoa.extended.tck.specs.PingSpec;
@@ -54,7 +55,7 @@ public class JavaFileConverterTest extends AbstractSpecTest {
         String packageName = "org.openapitools.empoa.extended.tck.specs";
         String className = toClassName(spec);
 
-        OpenAPI openAPI = createOpenAPI(spec);
+        OpenAPI openAPI = getOpenAPISpec(spec);
         // tag::usage[]
         JavaFile javaFile = JavaFileConverter.createOpenAPI(openAPI, packageName, className);
         String javaCode = javaFile.toString();
@@ -77,6 +78,8 @@ public class JavaFileConverterTest extends AbstractSpecTest {
             return TodoappSpec.class.getSimpleName();
         case MULTIPLE_RESPONSES:
             return MultipleResponsesSpec.class.getSimpleName();
+        case BIG:
+            return BigSpec.class.getSimpleName();
         default:
             throw new IllegalArgumentException("Unknown spec: " + spec);
         }

--- a/empoa-swagger-core/src/test/java/org/openapitools/empoa/swagger/core/tck/ParserAndSerializerWithGsonTckTest.java
+++ b/empoa-swagger-core/src/test/java/org/openapitools/empoa/swagger/core/tck/ParserAndSerializerWithGsonTckTest.java
@@ -33,7 +33,7 @@ import io.swagger.v3.parser.core.models.SwaggerParseResult;
 public class ParserAndSerializerWithGsonTckTest extends AbstractSerializerTest {
 
     @Override
-    protected OpenAPI createOpenAPI(Specs spec) throws IOException {
+    protected OpenAPI getOpenAPISpec(Specs spec) throws IOException {
         String json = readInputFromResource(spec);
 
         OpenAPIParser openApiParser = new OpenAPIParser();
@@ -52,15 +52,47 @@ public class ParserAndSerializerWithGsonTckTest extends AbstractSerializerTest {
                 .getPathItem("/hello/{name}")
                 .getGET()
                 .getParameters();
-            Parameter nameParameter = parameters.get(0);
-            nameParameter.setExplode(null);
-            nameParameter.setStyle(null);
-            Parameter languageParameter = parameters.get(1);
-            languageParameter.setExplode(null);
-            languageParameter.setRequired(null);
-            languageParameter.setStyle(null);
+            set2ValuesToNull(parameters.get(0));
+            set3ValuesToNull(parameters.get(1));
+        } else if (Specs.BIG == spec) {
+            set2ValuesToNull(
+                openAPI.getPaths()
+                    .getPathItem("/tree/{name}")
+                    .getGET()
+                    .getParameters()
+                    .get(0)
+            );
+            set2ValuesToNull(
+                openAPI.getPaths()
+                    .getPathItem("/messages/{id}")
+                    .getParameters()
+                    .get(0)
+            );
+            set3ValuesToNull(
+                openAPI.getPaths()
+                    .getPathItem("/messages/{id}")
+                    .getPUT()
+                    .getParameters()
+                    .get(0)
+            );
+            set3ValuesToNull(
+                openAPI.getComponents()
+                    .getParameters()
+                    .get("LanguageParam")
+            );
         }
         return openAPI;
+    }
+
+    private void set2ValuesToNull(Parameter languageParameter) {
+        languageParameter.setExplode(null);
+        languageParameter.setStyle(null);
+    }
+
+    private void set3ValuesToNull(Parameter languageParameter) {
+        languageParameter.setExplode(null);
+        languageParameter.setRequired(null);
+        languageParameter.setStyle(null);
     }
 
     @Override


### PR DESCRIPTION
Fixes #9: Use 'default' instead of 'defaultValue' in the gson serializer.