### PR TITLE
Add a Utility method to sort the maps contained in a Spec

### DIFF
--- a/empoa-generator/src/main/java/org/openapitools/empoa/generator/util/SortMapsConfigGenerator.java
+++ b/empoa-generator/src/main/java/org/openapitools/empoa/generator/util/SortMapsConfigGenerator.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright 2020 Jeremie Bresson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+package org.openapitools.empoa.generator.util;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.openapitools.empoa.generator.Input;
+import org.openapitools.empoa.specs.Element;
+import org.openapitools.empoa.specs.MapMember;
+import org.openapitools.empoa.util.FileUtil;
+import org.openapitools.empoa.util.StringUtil;
+
+public class SortMapsConfigGenerator {
+
+    static final String CLASS_NAME = "SortMapsConfig";
+    private Map<Element, List<MapMember>> map;
+    private Input input;
+
+    public SortMapsConfigGenerator(Map<Element, List<MapMember>> map, Input input) {
+        this.map = map;
+        this.input = input;
+    }
+
+    public String generateContent() {
+        List<String> booleans = new ArrayList<String>();
+        for (Map.Entry<Element, List<MapMember>> entry : map.entrySet()) {
+            Element e = entry.getKey();
+            for (MapMember member : entry.getValue()) {
+                booleans.add(booleanName(e, member));
+            }
+        }
+        Collections.sort(booleans);
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("package " + input.rootPackage + ";\n");
+        sb.append("\n");
+        sb.append("public class " + CLASS_NAME);
+        sb.append(" {\n");
+        sb.append("\n");
+        for (String b : booleans) {
+            sb.append("    private boolean " + b + " = true;\n");
+        }
+        sb.append("\n");
+        for (String b : booleans) {
+            sb.append("    public boolean get" + StringUtil.capitalize(b) + "() {\n");
+            sb.append("        return " + b + ";\n");
+            sb.append("    }\n");
+            sb.append("\n");
+            sb.append("    public void set" + StringUtil.capitalize(b) + "(boolean value) {\n");
+            sb.append("        " + b + " = value;\n");
+            sb.append("    }\n");
+            sb.append("\n");
+            sb.append("    public " + CLASS_NAME + " " + b + "(boolean value) {\n");
+            sb.append("        " + b + " = value;\n");
+            sb.append("        return this;\n");
+            sb.append("    }\n");
+            sb.append("\n");
+        }
+        sb.append("}\n");
+
+        return sb.toString();
+    }
+
+    private String booleanName(Element e, MapMember member) {
+        return "sort" + e.type.name() + member.name;
+    }
+
+    public void writeFile() throws IOException {
+        FileUtil.writeJavaClass(input.srcFolder, input.rootPackage, CLASS_NAME, generateContent());
+    }
+}

--- a/empoa-generator/src/main/java/org/openapitools/empoa/generator/util/SortMapsGenerator.java
+++ b/empoa-generator/src/main/java/org/openapitools/empoa/generator/util/SortMapsGenerator.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright 2020 Jeremie Bresson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+package org.openapitools.empoa.generator.util;
+
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+import org.openapitools.empoa.generator.Input;
+import org.openapitools.empoa.specs.Element;
+import org.openapitools.empoa.specs.MapMember;
+import org.openapitools.empoa.util.FileUtil;
+import org.openapitools.empoa.util.StringUtil;
+
+public class SortMapsGenerator {
+
+    static final String CLASS_NAME = "SortMapsVisitor";
+    private Map<Element, List<MapMember>> map;
+    private Input input;
+
+    public SortMapsGenerator(Map<Element, List<MapMember>> map, Input input) {
+        this.map = map;
+        this.input = input;
+    }
+
+    public String generateContent() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("package " + input.rootPackage + ";\n");
+        sb.append("\n");
+        sb.append("import java.util.TreeMap;\n");
+        sb.append("\n");
+        map.keySet()
+            .stream()
+            .sorted(Comparator.comparing(e -> e.fqName))
+            .forEach(element -> {
+                sb.append("import " + element.fqName + ";\n");
+            });
+        sb.append("import org.openapitools.empoa.util.visitor.OASVisitResult;\n");
+        sb.append("import org.openapitools.empoa.util.visitor.OASVisitorAdapter;\n");
+        sb.append("\n");
+        sb.append("class " + CLASS_NAME);
+        sb.append(" extends OASVisitorAdapter {\n");
+        sb.append("\n");
+        sb.append("    private " + SortMapsConfigGenerator.CLASS_NAME + " config;\n");
+        sb.append("\n");
+        sb.append("    " + CLASS_NAME + "(" + SortMapsConfigGenerator.CLASS_NAME + " config) {\n");
+        sb.append("        this.config = config;\n");
+        sb.append("    }\n");
+        sb.append("\n");
+        map.entrySet()
+            .stream()
+            .sorted(Comparator.comparing(Map.Entry::getKey, new ElementComparator()))
+            .forEach(entry -> {
+                Element element = entry.getKey();
+                String simpleName = StringUtil.computeSimpleName(element.fqName);
+                String varName = StringUtil.decapitalize(simpleName);
+                sb.append("    @Override\n");
+                sb.append("    public OASVisitResult visit(" + simpleName + " " + varName + ", String jsonPath) {\n");
+                for (MapMember member : entry.getValue()) {
+                    sb.append("        if (config.get" + booleanName(element, member) + "() && " + varName + "." + member.getterName + "() != null) {\n");
+                    sb.append("            " + varName + "." + member.setterName + "(new TreeMap<>(" + varName + "." + member.getterName + "()));\n");
+                    sb.append("        }\n");
+                }
+                sb.append("        return OASVisitResult.CONTINUE;\n");
+                sb.append("    }\n");
+                sb.append("\n");
+            });
+        sb.append("}\n");
+
+        return sb.toString();
+    }
+
+    private String booleanName(Element e, MapMember member) {
+        return "Sort" + e.type.name() + member.name;
+    }
+
+    public void writeFile() throws IOException {
+        FileUtil.writeJavaClass(input.srcFolder, input.rootPackage, CLASS_NAME, generateContent());
+    }
+}

--- a/empoa-generator/src/main/java/org/openapitools/empoa/generator/util/SortMapsGeneratorMain.java
+++ b/empoa-generator/src/main/java/org/openapitools/empoa/generator/util/SortMapsGeneratorMain.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright 2020 Jeremie Bresson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+package org.openapitools.empoa.generator.util;
+
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.openapitools.empoa.generator.Input;
+import org.openapitools.empoa.specs.Element;
+import org.openapitools.empoa.specs.IMember;
+import org.openapitools.empoa.specs.MapMember;
+import org.openapitools.empoa.specs.OpenAPISpec;
+
+public class SortMapsGeneratorMain {
+
+    public static void main(String[] args) throws Exception {
+        Map<Element, List<MapMember>> map = new HashMap<>();
+        for (Element e : OpenAPISpec.elements()) {
+            for (IMember m : e.members) {
+                if (m instanceof MapMember) {
+                    MapMember member = (MapMember) m;
+                    List<MapMember> l = map.computeIfAbsent(e, k -> new ArrayList<>());
+                    l.add(member);
+                }
+            }
+            if (e.extensible) {
+                List<MapMember> l = map.computeIfAbsent(e, k -> new ArrayList<>());
+                MapMember member = new MapMember(null, "Extensions", "java.util.Object");
+                l.add(member);
+            }
+        }
+        Input input1 = new Input(Paths.get("../empoa-util/src/main/java"), "org.openapitools.empoa.util");
+        SortMapsGenerator generator1 = new SortMapsGenerator(map, input1);
+        generator1.writeFile();
+        Input input2 = new Input(Paths.get("../empoa-util/src/main/java"), "org.openapitools.empoa.util");
+        SortMapsConfigGenerator generator2 = new SortMapsConfigGenerator(map, input2);
+        generator2.writeFile();
+    }
+}

--- a/empoa-util/build.gradle
+++ b/empoa-util/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
     testImplementation "org.assertj:assertj-core:$assertjVersion"
+    testImplementation "net.javacrumbs.json-unit:json-unit-assertj:$jsonUnitVersion"
     testImplementation project(':empoa-extended-tck')
     testImplementation project(':empoa-gson-serializer')
     testImplementation "com.jayway.jsonpath:json-path:$jsonpathVersion"

--- a/empoa-util/src/main/java/org/openapitools/empoa/util/OASUtil.java
+++ b/empoa-util/src/main/java/org/openapitools/empoa/util/OASUtil.java
@@ -28,6 +28,7 @@ import org.eclipse.microprofile.openapi.models.parameters.Parameter;
 import org.eclipse.microprofile.openapi.models.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.models.responses.APIResponse;
 import org.eclipse.microprofile.openapi.models.security.SecurityScheme;
+import org.openapitools.empoa.util.visitor.OASAccept;
 
 public class OASUtil {
 
@@ -40,6 +41,15 @@ public class OASUtil {
     public static final String REF_PREFIX_REQUEST_BODY = "#/components/requestBodies/";
     public static final String REF_PREFIX_SCHEMA = "#/components/schemas/";
     public static final String REF_PREFIX_SECURITY_SCHEME = "#/components/securitySchemes/";
+
+    public static void sortMaps(OpenAPI openAPI) {
+        sortMaps(openAPI, new SortMapsConfig());
+    }
+
+    public static void sortMaps(OpenAPI openAPI, SortMapsConfig config) {
+        SortMapsVisitor visitor = new SortMapsVisitor(config);
+        OASAccept.accept(visitor, openAPI);
+    }
 
     public static boolean containsAPIResponse(OpenAPI openAPI, String refValue) {
         String simpleName = toSimpleName(REF_PREFIX_API_RESPONSE, refValue);

--- a/empoa-util/src/main/java/org/openapitools/empoa/util/SortMapsConfig.java
+++ b/empoa-util/src/main/java/org/openapitools/empoa/util/SortMapsConfig.java
@@ -1,0 +1,805 @@
+/*******************************************************************************
+ * Copyright 2020 Jeremie Bresson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+package org.openapitools.empoa.util;
+
+public class SortMapsConfig {
+
+    private boolean sortAPIResponseExtensions = true;
+    private boolean sortAPIResponseHeaders = true;
+    private boolean sortAPIResponseLinks = true;
+    private boolean sortAPIResponsesAPIResponses = true;
+    private boolean sortAPIResponsesExtensions = true;
+    private boolean sortCallbackExtensions = true;
+    private boolean sortCallbackPathItems = true;
+    private boolean sortComponentsCallbacks = true;
+    private boolean sortComponentsExamples = true;
+    private boolean sortComponentsExtensions = true;
+    private boolean sortComponentsHeaders = true;
+    private boolean sortComponentsLinks = true;
+    private boolean sortComponentsParameters = true;
+    private boolean sortComponentsRequestBodies = true;
+    private boolean sortComponentsResponses = true;
+    private boolean sortComponentsSchemas = true;
+    private boolean sortComponentsSecuritySchemes = true;
+    private boolean sortContactExtensions = true;
+    private boolean sortContentMediaTypes = true;
+    private boolean sortDiscriminatorMapping = true;
+    private boolean sortEncodingExtensions = true;
+    private boolean sortEncodingHeaders = true;
+    private boolean sortExampleExtensions = true;
+    private boolean sortExternalDocumentationExtensions = true;
+    private boolean sortHeaderExamples = true;
+    private boolean sortHeaderExtensions = true;
+    private boolean sortInfoExtensions = true;
+    private boolean sortLicenseExtensions = true;
+    private boolean sortLinkExtensions = true;
+    private boolean sortLinkParameters = true;
+    private boolean sortMediaTypeEncoding = true;
+    private boolean sortMediaTypeExamples = true;
+    private boolean sortMediaTypeExtensions = true;
+    private boolean sortOAuthFlowExtensions = true;
+    private boolean sortOAuthFlowsExtensions = true;
+    private boolean sortOpenAPIExtensions = true;
+    private boolean sortOperationCallbacks = true;
+    private boolean sortOperationExtensions = true;
+    private boolean sortParameterExamples = true;
+    private boolean sortParameterExtensions = true;
+    private boolean sortPathItemExtensions = true;
+    private boolean sortPathsExtensions = true;
+    private boolean sortPathsPathItems = true;
+    private boolean sortRequestBodyExtensions = true;
+    private boolean sortSchemaExtensions = true;
+    private boolean sortSchemaProperties = true;
+    private boolean sortScopesExtensions = true;
+    private boolean sortScopesScopes = true;
+    private boolean sortSecurityRequirementSchemes = true;
+    private boolean sortSecuritySchemeExtensions = true;
+    private boolean sortServerExtensions = true;
+    private boolean sortServerVariableExtensions = true;
+    private boolean sortServerVariablesExtensions = true;
+    private boolean sortServerVariablesServerVariables = true;
+    private boolean sortTagExtensions = true;
+    private boolean sortXMLExtensions = true;
+
+    public boolean getSortAPIResponseExtensions() {
+        return sortAPIResponseExtensions;
+    }
+
+    public void setSortAPIResponseExtensions(boolean value) {
+        sortAPIResponseExtensions = value;
+    }
+
+    public SortMapsConfig sortAPIResponseExtensions(boolean value) {
+        sortAPIResponseExtensions = value;
+        return this;
+    }
+
+    public boolean getSortAPIResponseHeaders() {
+        return sortAPIResponseHeaders;
+    }
+
+    public void setSortAPIResponseHeaders(boolean value) {
+        sortAPIResponseHeaders = value;
+    }
+
+    public SortMapsConfig sortAPIResponseHeaders(boolean value) {
+        sortAPIResponseHeaders = value;
+        return this;
+    }
+
+    public boolean getSortAPIResponseLinks() {
+        return sortAPIResponseLinks;
+    }
+
+    public void setSortAPIResponseLinks(boolean value) {
+        sortAPIResponseLinks = value;
+    }
+
+    public SortMapsConfig sortAPIResponseLinks(boolean value) {
+        sortAPIResponseLinks = value;
+        return this;
+    }
+
+    public boolean getSortAPIResponsesAPIResponses() {
+        return sortAPIResponsesAPIResponses;
+    }
+
+    public void setSortAPIResponsesAPIResponses(boolean value) {
+        sortAPIResponsesAPIResponses = value;
+    }
+
+    public SortMapsConfig sortAPIResponsesAPIResponses(boolean value) {
+        sortAPIResponsesAPIResponses = value;
+        return this;
+    }
+
+    public boolean getSortAPIResponsesExtensions() {
+        return sortAPIResponsesExtensions;
+    }
+
+    public void setSortAPIResponsesExtensions(boolean value) {
+        sortAPIResponsesExtensions = value;
+    }
+
+    public SortMapsConfig sortAPIResponsesExtensions(boolean value) {
+        sortAPIResponsesExtensions = value;
+        return this;
+    }
+
+    public boolean getSortCallbackExtensions() {
+        return sortCallbackExtensions;
+    }
+
+    public void setSortCallbackExtensions(boolean value) {
+        sortCallbackExtensions = value;
+    }
+
+    public SortMapsConfig sortCallbackExtensions(boolean value) {
+        sortCallbackExtensions = value;
+        return this;
+    }
+
+    public boolean getSortCallbackPathItems() {
+        return sortCallbackPathItems;
+    }
+
+    public void setSortCallbackPathItems(boolean value) {
+        sortCallbackPathItems = value;
+    }
+
+    public SortMapsConfig sortCallbackPathItems(boolean value) {
+        sortCallbackPathItems = value;
+        return this;
+    }
+
+    public boolean getSortComponentsCallbacks() {
+        return sortComponentsCallbacks;
+    }
+
+    public void setSortComponentsCallbacks(boolean value) {
+        sortComponentsCallbacks = value;
+    }
+
+    public SortMapsConfig sortComponentsCallbacks(boolean value) {
+        sortComponentsCallbacks = value;
+        return this;
+    }
+
+    public boolean getSortComponentsExamples() {
+        return sortComponentsExamples;
+    }
+
+    public void setSortComponentsExamples(boolean value) {
+        sortComponentsExamples = value;
+    }
+
+    public SortMapsConfig sortComponentsExamples(boolean value) {
+        sortComponentsExamples = value;
+        return this;
+    }
+
+    public boolean getSortComponentsExtensions() {
+        return sortComponentsExtensions;
+    }
+
+    public void setSortComponentsExtensions(boolean value) {
+        sortComponentsExtensions = value;
+    }
+
+    public SortMapsConfig sortComponentsExtensions(boolean value) {
+        sortComponentsExtensions = value;
+        return this;
+    }
+
+    public boolean getSortComponentsHeaders() {
+        return sortComponentsHeaders;
+    }
+
+    public void setSortComponentsHeaders(boolean value) {
+        sortComponentsHeaders = value;
+    }
+
+    public SortMapsConfig sortComponentsHeaders(boolean value) {
+        sortComponentsHeaders = value;
+        return this;
+    }
+
+    public boolean getSortComponentsLinks() {
+        return sortComponentsLinks;
+    }
+
+    public void setSortComponentsLinks(boolean value) {
+        sortComponentsLinks = value;
+    }
+
+    public SortMapsConfig sortComponentsLinks(boolean value) {
+        sortComponentsLinks = value;
+        return this;
+    }
+
+    public boolean getSortComponentsParameters() {
+        return sortComponentsParameters;
+    }
+
+    public void setSortComponentsParameters(boolean value) {
+        sortComponentsParameters = value;
+    }
+
+    public SortMapsConfig sortComponentsParameters(boolean value) {
+        sortComponentsParameters = value;
+        return this;
+    }
+
+    public boolean getSortComponentsRequestBodies() {
+        return sortComponentsRequestBodies;
+    }
+
+    public void setSortComponentsRequestBodies(boolean value) {
+        sortComponentsRequestBodies = value;
+    }
+
+    public SortMapsConfig sortComponentsRequestBodies(boolean value) {
+        sortComponentsRequestBodies = value;
+        return this;
+    }
+
+    public boolean getSortComponentsResponses() {
+        return sortComponentsResponses;
+    }
+
+    public void setSortComponentsResponses(boolean value) {
+        sortComponentsResponses = value;
+    }
+
+    public SortMapsConfig sortComponentsResponses(boolean value) {
+        sortComponentsResponses = value;
+        return this;
+    }
+
+    public boolean getSortComponentsSchemas() {
+        return sortComponentsSchemas;
+    }
+
+    public void setSortComponentsSchemas(boolean value) {
+        sortComponentsSchemas = value;
+    }
+
+    public SortMapsConfig sortComponentsSchemas(boolean value) {
+        sortComponentsSchemas = value;
+        return this;
+    }
+
+    public boolean getSortComponentsSecuritySchemes() {
+        return sortComponentsSecuritySchemes;
+    }
+
+    public void setSortComponentsSecuritySchemes(boolean value) {
+        sortComponentsSecuritySchemes = value;
+    }
+
+    public SortMapsConfig sortComponentsSecuritySchemes(boolean value) {
+        sortComponentsSecuritySchemes = value;
+        return this;
+    }
+
+    public boolean getSortContactExtensions() {
+        return sortContactExtensions;
+    }
+
+    public void setSortContactExtensions(boolean value) {
+        sortContactExtensions = value;
+    }
+
+    public SortMapsConfig sortContactExtensions(boolean value) {
+        sortContactExtensions = value;
+        return this;
+    }
+
+    public boolean getSortContentMediaTypes() {
+        return sortContentMediaTypes;
+    }
+
+    public void setSortContentMediaTypes(boolean value) {
+        sortContentMediaTypes = value;
+    }
+
+    public SortMapsConfig sortContentMediaTypes(boolean value) {
+        sortContentMediaTypes = value;
+        return this;
+    }
+
+    public boolean getSortDiscriminatorMapping() {
+        return sortDiscriminatorMapping;
+    }
+
+    public void setSortDiscriminatorMapping(boolean value) {
+        sortDiscriminatorMapping = value;
+    }
+
+    public SortMapsConfig sortDiscriminatorMapping(boolean value) {
+        sortDiscriminatorMapping = value;
+        return this;
+    }
+
+    public boolean getSortEncodingExtensions() {
+        return sortEncodingExtensions;
+    }
+
+    public void setSortEncodingExtensions(boolean value) {
+        sortEncodingExtensions = value;
+    }
+
+    public SortMapsConfig sortEncodingExtensions(boolean value) {
+        sortEncodingExtensions = value;
+        return this;
+    }
+
+    public boolean getSortEncodingHeaders() {
+        return sortEncodingHeaders;
+    }
+
+    public void setSortEncodingHeaders(boolean value) {
+        sortEncodingHeaders = value;
+    }
+
+    public SortMapsConfig sortEncodingHeaders(boolean value) {
+        sortEncodingHeaders = value;
+        return this;
+    }
+
+    public boolean getSortExampleExtensions() {
+        return sortExampleExtensions;
+    }
+
+    public void setSortExampleExtensions(boolean value) {
+        sortExampleExtensions = value;
+    }
+
+    public SortMapsConfig sortExampleExtensions(boolean value) {
+        sortExampleExtensions = value;
+        return this;
+    }
+
+    public boolean getSortExternalDocumentationExtensions() {
+        return sortExternalDocumentationExtensions;
+    }
+
+    public void setSortExternalDocumentationExtensions(boolean value) {
+        sortExternalDocumentationExtensions = value;
+    }
+
+    public SortMapsConfig sortExternalDocumentationExtensions(boolean value) {
+        sortExternalDocumentationExtensions = value;
+        return this;
+    }
+
+    public boolean getSortHeaderExamples() {
+        return sortHeaderExamples;
+    }
+
+    public void setSortHeaderExamples(boolean value) {
+        sortHeaderExamples = value;
+    }
+
+    public SortMapsConfig sortHeaderExamples(boolean value) {
+        sortHeaderExamples = value;
+        return this;
+    }
+
+    public boolean getSortHeaderExtensions() {
+        return sortHeaderExtensions;
+    }
+
+    public void setSortHeaderExtensions(boolean value) {
+        sortHeaderExtensions = value;
+    }
+
+    public SortMapsConfig sortHeaderExtensions(boolean value) {
+        sortHeaderExtensions = value;
+        return this;
+    }
+
+    public boolean getSortInfoExtensions() {
+        return sortInfoExtensions;
+    }
+
+    public void setSortInfoExtensions(boolean value) {
+        sortInfoExtensions = value;
+    }
+
+    public SortMapsConfig sortInfoExtensions(boolean value) {
+        sortInfoExtensions = value;
+        return this;
+    }
+
+    public boolean getSortLicenseExtensions() {
+        return sortLicenseExtensions;
+    }
+
+    public void setSortLicenseExtensions(boolean value) {
+        sortLicenseExtensions = value;
+    }
+
+    public SortMapsConfig sortLicenseExtensions(boolean value) {
+        sortLicenseExtensions = value;
+        return this;
+    }
+
+    public boolean getSortLinkExtensions() {
+        return sortLinkExtensions;
+    }
+
+    public void setSortLinkExtensions(boolean value) {
+        sortLinkExtensions = value;
+    }
+
+    public SortMapsConfig sortLinkExtensions(boolean value) {
+        sortLinkExtensions = value;
+        return this;
+    }
+
+    public boolean getSortLinkParameters() {
+        return sortLinkParameters;
+    }
+
+    public void setSortLinkParameters(boolean value) {
+        sortLinkParameters = value;
+    }
+
+    public SortMapsConfig sortLinkParameters(boolean value) {
+        sortLinkParameters = value;
+        return this;
+    }
+
+    public boolean getSortMediaTypeEncoding() {
+        return sortMediaTypeEncoding;
+    }
+
+    public void setSortMediaTypeEncoding(boolean value) {
+        sortMediaTypeEncoding = value;
+    }
+
+    public SortMapsConfig sortMediaTypeEncoding(boolean value) {
+        sortMediaTypeEncoding = value;
+        return this;
+    }
+
+    public boolean getSortMediaTypeExamples() {
+        return sortMediaTypeExamples;
+    }
+
+    public void setSortMediaTypeExamples(boolean value) {
+        sortMediaTypeExamples = value;
+    }
+
+    public SortMapsConfig sortMediaTypeExamples(boolean value) {
+        sortMediaTypeExamples = value;
+        return this;
+    }
+
+    public boolean getSortMediaTypeExtensions() {
+        return sortMediaTypeExtensions;
+    }
+
+    public void setSortMediaTypeExtensions(boolean value) {
+        sortMediaTypeExtensions = value;
+    }
+
+    public SortMapsConfig sortMediaTypeExtensions(boolean value) {
+        sortMediaTypeExtensions = value;
+        return this;
+    }
+
+    public boolean getSortOAuthFlowExtensions() {
+        return sortOAuthFlowExtensions;
+    }
+
+    public void setSortOAuthFlowExtensions(boolean value) {
+        sortOAuthFlowExtensions = value;
+    }
+
+    public SortMapsConfig sortOAuthFlowExtensions(boolean value) {
+        sortOAuthFlowExtensions = value;
+        return this;
+    }
+
+    public boolean getSortOAuthFlowsExtensions() {
+        return sortOAuthFlowsExtensions;
+    }
+
+    public void setSortOAuthFlowsExtensions(boolean value) {
+        sortOAuthFlowsExtensions = value;
+    }
+
+    public SortMapsConfig sortOAuthFlowsExtensions(boolean value) {
+        sortOAuthFlowsExtensions = value;
+        return this;
+    }
+
+    public boolean getSortOpenAPIExtensions() {
+        return sortOpenAPIExtensions;
+    }
+
+    public void setSortOpenAPIExtensions(boolean value) {
+        sortOpenAPIExtensions = value;
+    }
+
+    public SortMapsConfig sortOpenAPIExtensions(boolean value) {
+        sortOpenAPIExtensions = value;
+        return this;
+    }
+
+    public boolean getSortOperationCallbacks() {
+        return sortOperationCallbacks;
+    }
+
+    public void setSortOperationCallbacks(boolean value) {
+        sortOperationCallbacks = value;
+    }
+
+    public SortMapsConfig sortOperationCallbacks(boolean value) {
+        sortOperationCallbacks = value;
+        return this;
+    }
+
+    public boolean getSortOperationExtensions() {
+        return sortOperationExtensions;
+    }
+
+    public void setSortOperationExtensions(boolean value) {
+        sortOperationExtensions = value;
+    }
+
+    public SortMapsConfig sortOperationExtensions(boolean value) {
+        sortOperationExtensions = value;
+        return this;
+    }
+
+    public boolean getSortParameterExamples() {
+        return sortParameterExamples;
+    }
+
+    public void setSortParameterExamples(boolean value) {
+        sortParameterExamples = value;
+    }
+
+    public SortMapsConfig sortParameterExamples(boolean value) {
+        sortParameterExamples = value;
+        return this;
+    }
+
+    public boolean getSortParameterExtensions() {
+        return sortParameterExtensions;
+    }
+
+    public void setSortParameterExtensions(boolean value) {
+        sortParameterExtensions = value;
+    }
+
+    public SortMapsConfig sortParameterExtensions(boolean value) {
+        sortParameterExtensions = value;
+        return this;
+    }
+
+    public boolean getSortPathItemExtensions() {
+        return sortPathItemExtensions;
+    }
+
+    public void setSortPathItemExtensions(boolean value) {
+        sortPathItemExtensions = value;
+    }
+
+    public SortMapsConfig sortPathItemExtensions(boolean value) {
+        sortPathItemExtensions = value;
+        return this;
+    }
+
+    public boolean getSortPathsExtensions() {
+        return sortPathsExtensions;
+    }
+
+    public void setSortPathsExtensions(boolean value) {
+        sortPathsExtensions = value;
+    }
+
+    public SortMapsConfig sortPathsExtensions(boolean value) {
+        sortPathsExtensions = value;
+        return this;
+    }
+
+    public boolean getSortPathsPathItems() {
+        return sortPathsPathItems;
+    }
+
+    public void setSortPathsPathItems(boolean value) {
+        sortPathsPathItems = value;
+    }
+
+    public SortMapsConfig sortPathsPathItems(boolean value) {
+        sortPathsPathItems = value;
+        return this;
+    }
+
+    public boolean getSortRequestBodyExtensions() {
+        return sortRequestBodyExtensions;
+    }
+
+    public void setSortRequestBodyExtensions(boolean value) {
+        sortRequestBodyExtensions = value;
+    }
+
+    public SortMapsConfig sortRequestBodyExtensions(boolean value) {
+        sortRequestBodyExtensions = value;
+        return this;
+    }
+
+    public boolean getSortSchemaExtensions() {
+        return sortSchemaExtensions;
+    }
+
+    public void setSortSchemaExtensions(boolean value) {
+        sortSchemaExtensions = value;
+    }
+
+    public SortMapsConfig sortSchemaExtensions(boolean value) {
+        sortSchemaExtensions = value;
+        return this;
+    }
+
+    public boolean getSortSchemaProperties() {
+        return sortSchemaProperties;
+    }
+
+    public void setSortSchemaProperties(boolean value) {
+        sortSchemaProperties = value;
+    }
+
+    public SortMapsConfig sortSchemaProperties(boolean value) {
+        sortSchemaProperties = value;
+        return this;
+    }
+
+    public boolean getSortScopesExtensions() {
+        return sortScopesExtensions;
+    }
+
+    public void setSortScopesExtensions(boolean value) {
+        sortScopesExtensions = value;
+    }
+
+    public SortMapsConfig sortScopesExtensions(boolean value) {
+        sortScopesExtensions = value;
+        return this;
+    }
+
+    public boolean getSortScopesScopes() {
+        return sortScopesScopes;
+    }
+
+    public void setSortScopesScopes(boolean value) {
+        sortScopesScopes = value;
+    }
+
+    public SortMapsConfig sortScopesScopes(boolean value) {
+        sortScopesScopes = value;
+        return this;
+    }
+
+    public boolean getSortSecurityRequirementSchemes() {
+        return sortSecurityRequirementSchemes;
+    }
+
+    public void setSortSecurityRequirementSchemes(boolean value) {
+        sortSecurityRequirementSchemes = value;
+    }
+
+    public SortMapsConfig sortSecurityRequirementSchemes(boolean value) {
+        sortSecurityRequirementSchemes = value;
+        return this;
+    }
+
+    public boolean getSortSecuritySchemeExtensions() {
+        return sortSecuritySchemeExtensions;
+    }
+
+    public void setSortSecuritySchemeExtensions(boolean value) {
+        sortSecuritySchemeExtensions = value;
+    }
+
+    public SortMapsConfig sortSecuritySchemeExtensions(boolean value) {
+        sortSecuritySchemeExtensions = value;
+        return this;
+    }
+
+    public boolean getSortServerExtensions() {
+        return sortServerExtensions;
+    }
+
+    public void setSortServerExtensions(boolean value) {
+        sortServerExtensions = value;
+    }
+
+    public SortMapsConfig sortServerExtensions(boolean value) {
+        sortServerExtensions = value;
+        return this;
+    }
+
+    public boolean getSortServerVariableExtensions() {
+        return sortServerVariableExtensions;
+    }
+
+    public void setSortServerVariableExtensions(boolean value) {
+        sortServerVariableExtensions = value;
+    }
+
+    public SortMapsConfig sortServerVariableExtensions(boolean value) {
+        sortServerVariableExtensions = value;
+        return this;
+    }
+
+    public boolean getSortServerVariablesExtensions() {
+        return sortServerVariablesExtensions;
+    }
+
+    public void setSortServerVariablesExtensions(boolean value) {
+        sortServerVariablesExtensions = value;
+    }
+
+    public SortMapsConfig sortServerVariablesExtensions(boolean value) {
+        sortServerVariablesExtensions = value;
+        return this;
+    }
+
+    public boolean getSortServerVariablesServerVariables() {
+        return sortServerVariablesServerVariables;
+    }
+
+    public void setSortServerVariablesServerVariables(boolean value) {
+        sortServerVariablesServerVariables = value;
+    }
+
+    public SortMapsConfig sortServerVariablesServerVariables(boolean value) {
+        sortServerVariablesServerVariables = value;
+        return this;
+    }
+
+    public boolean getSortTagExtensions() {
+        return sortTagExtensions;
+    }
+
+    public void setSortTagExtensions(boolean value) {
+        sortTagExtensions = value;
+    }
+
+    public SortMapsConfig sortTagExtensions(boolean value) {
+        sortTagExtensions = value;
+        return this;
+    }
+
+    public boolean getSortXMLExtensions() {
+        return sortXMLExtensions;
+    }
+
+    public void setSortXMLExtensions(boolean value) {
+        sortXMLExtensions = value;
+    }
+
+    public SortMapsConfig sortXMLExtensions(boolean value) {
+        sortXMLExtensions = value;
+        return this;
+    }
+
+}

--- a/empoa-util/src/main/java/org/openapitools/empoa/util/SortMapsVisitor.java
+++ b/empoa-util/src/main/java/org/openapitools/empoa/util/SortMapsVisitor.java
@@ -1,0 +1,391 @@
+/*******************************************************************************
+ * Copyright 2020 Jeremie Bresson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+package org.openapitools.empoa.util;
+
+import java.util.TreeMap;
+
+import org.eclipse.microprofile.openapi.models.Components;
+import org.eclipse.microprofile.openapi.models.ExternalDocumentation;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.Operation;
+import org.eclipse.microprofile.openapi.models.PathItem;
+import org.eclipse.microprofile.openapi.models.Paths;
+import org.eclipse.microprofile.openapi.models.callbacks.Callback;
+import org.eclipse.microprofile.openapi.models.examples.Example;
+import org.eclipse.microprofile.openapi.models.headers.Header;
+import org.eclipse.microprofile.openapi.models.info.Contact;
+import org.eclipse.microprofile.openapi.models.info.Info;
+import org.eclipse.microprofile.openapi.models.info.License;
+import org.eclipse.microprofile.openapi.models.links.Link;
+import org.eclipse.microprofile.openapi.models.media.Content;
+import org.eclipse.microprofile.openapi.models.media.Discriminator;
+import org.eclipse.microprofile.openapi.models.media.Encoding;
+import org.eclipse.microprofile.openapi.models.media.MediaType;
+import org.eclipse.microprofile.openapi.models.media.Schema;
+import org.eclipse.microprofile.openapi.models.media.XML;
+import org.eclipse.microprofile.openapi.models.parameters.Parameter;
+import org.eclipse.microprofile.openapi.models.parameters.RequestBody;
+import org.eclipse.microprofile.openapi.models.responses.APIResponse;
+import org.eclipse.microprofile.openapi.models.responses.APIResponses;
+import org.eclipse.microprofile.openapi.models.security.OAuthFlow;
+import org.eclipse.microprofile.openapi.models.security.OAuthFlows;
+import org.eclipse.microprofile.openapi.models.security.Scopes;
+import org.eclipse.microprofile.openapi.models.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.models.security.SecurityScheme;
+import org.eclipse.microprofile.openapi.models.servers.Server;
+import org.eclipse.microprofile.openapi.models.servers.ServerVariable;
+import org.eclipse.microprofile.openapi.models.servers.ServerVariables;
+import org.eclipse.microprofile.openapi.models.tags.Tag;
+import org.openapitools.empoa.util.visitor.OASVisitResult;
+import org.openapitools.empoa.util.visitor.OASVisitorAdapter;
+
+class SortMapsVisitor extends OASVisitorAdapter {
+
+    private SortMapsConfig config;
+
+    SortMapsVisitor(SortMapsConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public OASVisitResult visit(OpenAPI openAPI, String jsonPath) {
+        if (config.getSortOpenAPIExtensions() && openAPI.getExtensions() != null) {
+            openAPI.setExtensions(new TreeMap<>(openAPI.getExtensions()));
+        }
+        return OASVisitResult.CONTINUE;
+    }
+
+    @Override
+    public OASVisitResult visit(APIResponse apiResponse, String jsonPath) {
+        if (config.getSortAPIResponseHeaders() && apiResponse.getHeaders() != null) {
+            apiResponse.setHeaders(new TreeMap<>(apiResponse.getHeaders()));
+        }
+        if (config.getSortAPIResponseLinks() && apiResponse.getLinks() != null) {
+            apiResponse.setLinks(new TreeMap<>(apiResponse.getLinks()));
+        }
+        if (config.getSortAPIResponseExtensions() && apiResponse.getExtensions() != null) {
+            apiResponse.setExtensions(new TreeMap<>(apiResponse.getExtensions()));
+        }
+        return OASVisitResult.CONTINUE;
+    }
+
+    @Override
+    public OASVisitResult visit(APIResponses apiResponses, String jsonPath) {
+        if (config.getSortAPIResponsesAPIResponses() && apiResponses.getAPIResponses() != null) {
+            apiResponses.setAPIResponses(new TreeMap<>(apiResponses.getAPIResponses()));
+        }
+        if (config.getSortAPIResponsesExtensions() && apiResponses.getExtensions() != null) {
+            apiResponses.setExtensions(new TreeMap<>(apiResponses.getExtensions()));
+        }
+        return OASVisitResult.CONTINUE;
+    }
+
+    @Override
+    public OASVisitResult visit(Callback callback, String jsonPath) {
+        if (config.getSortCallbackPathItems() && callback.getPathItems() != null) {
+            callback.setPathItems(new TreeMap<>(callback.getPathItems()));
+        }
+        if (config.getSortCallbackExtensions() && callback.getExtensions() != null) {
+            callback.setExtensions(new TreeMap<>(callback.getExtensions()));
+        }
+        return OASVisitResult.CONTINUE;
+    }
+
+    @Override
+    public OASVisitResult visit(Components components, String jsonPath) {
+        if (config.getSortComponentsSchemas() && components.getSchemas() != null) {
+            components.setSchemas(new TreeMap<>(components.getSchemas()));
+        }
+        if (config.getSortComponentsResponses() && components.getResponses() != null) {
+            components.setResponses(new TreeMap<>(components.getResponses()));
+        }
+        if (config.getSortComponentsParameters() && components.getParameters() != null) {
+            components.setParameters(new TreeMap<>(components.getParameters()));
+        }
+        if (config.getSortComponentsExamples() && components.getExamples() != null) {
+            components.setExamples(new TreeMap<>(components.getExamples()));
+        }
+        if (config.getSortComponentsRequestBodies() && components.getRequestBodies() != null) {
+            components.setRequestBodies(new TreeMap<>(components.getRequestBodies()));
+        }
+        if (config.getSortComponentsHeaders() && components.getHeaders() != null) {
+            components.setHeaders(new TreeMap<>(components.getHeaders()));
+        }
+        if (config.getSortComponentsSecuritySchemes() && components.getSecuritySchemes() != null) {
+            components.setSecuritySchemes(new TreeMap<>(components.getSecuritySchemes()));
+        }
+        if (config.getSortComponentsLinks() && components.getLinks() != null) {
+            components.setLinks(new TreeMap<>(components.getLinks()));
+        }
+        if (config.getSortComponentsCallbacks() && components.getCallbacks() != null) {
+            components.setCallbacks(new TreeMap<>(components.getCallbacks()));
+        }
+        if (config.getSortComponentsExtensions() && components.getExtensions() != null) {
+            components.setExtensions(new TreeMap<>(components.getExtensions()));
+        }
+        return OASVisitResult.CONTINUE;
+    }
+
+    @Override
+    public OASVisitResult visit(Contact contact, String jsonPath) {
+        if (config.getSortContactExtensions() && contact.getExtensions() != null) {
+            contact.setExtensions(new TreeMap<>(contact.getExtensions()));
+        }
+        return OASVisitResult.CONTINUE;
+    }
+
+    @Override
+    public OASVisitResult visit(Content content, String jsonPath) {
+        if (config.getSortContentMediaTypes() && content.getMediaTypes() != null) {
+            content.setMediaTypes(new TreeMap<>(content.getMediaTypes()));
+        }
+        return OASVisitResult.CONTINUE;
+    }
+
+    @Override
+    public OASVisitResult visit(Discriminator discriminator, String jsonPath) {
+        if (config.getSortDiscriminatorMapping() && discriminator.getMapping() != null) {
+            discriminator.setMapping(new TreeMap<>(discriminator.getMapping()));
+        }
+        return OASVisitResult.CONTINUE;
+    }
+
+    @Override
+    public OASVisitResult visit(Encoding encoding, String jsonPath) {
+        if (config.getSortEncodingHeaders() && encoding.getHeaders() != null) {
+            encoding.setHeaders(new TreeMap<>(encoding.getHeaders()));
+        }
+        if (config.getSortEncodingExtensions() && encoding.getExtensions() != null) {
+            encoding.setExtensions(new TreeMap<>(encoding.getExtensions()));
+        }
+        return OASVisitResult.CONTINUE;
+    }
+
+    @Override
+    public OASVisitResult visit(Example example, String jsonPath) {
+        if (config.getSortExampleExtensions() && example.getExtensions() != null) {
+            example.setExtensions(new TreeMap<>(example.getExtensions()));
+        }
+        return OASVisitResult.CONTINUE;
+    }
+
+    @Override
+    public OASVisitResult visit(ExternalDocumentation externalDocumentation, String jsonPath) {
+        if (config.getSortExternalDocumentationExtensions() && externalDocumentation.getExtensions() != null) {
+            externalDocumentation.setExtensions(new TreeMap<>(externalDocumentation.getExtensions()));
+        }
+        return OASVisitResult.CONTINUE;
+    }
+
+    @Override
+    public OASVisitResult visit(Header header, String jsonPath) {
+        if (config.getSortHeaderExamples() && header.getExamples() != null) {
+            header.setExamples(new TreeMap<>(header.getExamples()));
+        }
+        if (config.getSortHeaderExtensions() && header.getExtensions() != null) {
+            header.setExtensions(new TreeMap<>(header.getExtensions()));
+        }
+        return OASVisitResult.CONTINUE;
+    }
+
+    @Override
+    public OASVisitResult visit(Info info, String jsonPath) {
+        if (config.getSortInfoExtensions() && info.getExtensions() != null) {
+            info.setExtensions(new TreeMap<>(info.getExtensions()));
+        }
+        return OASVisitResult.CONTINUE;
+    }
+
+    @Override
+    public OASVisitResult visit(License license, String jsonPath) {
+        if (config.getSortLicenseExtensions() && license.getExtensions() != null) {
+            license.setExtensions(new TreeMap<>(license.getExtensions()));
+        }
+        return OASVisitResult.CONTINUE;
+    }
+
+    @Override
+    public OASVisitResult visit(Link link, String jsonPath) {
+        if (config.getSortLinkParameters() && link.getParameters() != null) {
+            link.setParameters(new TreeMap<>(link.getParameters()));
+        }
+        if (config.getSortLinkExtensions() && link.getExtensions() != null) {
+            link.setExtensions(new TreeMap<>(link.getExtensions()));
+        }
+        return OASVisitResult.CONTINUE;
+    }
+
+    @Override
+    public OASVisitResult visit(MediaType mediaType, String jsonPath) {
+        if (config.getSortMediaTypeExamples() && mediaType.getExamples() != null) {
+            mediaType.setExamples(new TreeMap<>(mediaType.getExamples()));
+        }
+        if (config.getSortMediaTypeEncoding() && mediaType.getEncoding() != null) {
+            mediaType.setEncoding(new TreeMap<>(mediaType.getEncoding()));
+        }
+        if (config.getSortMediaTypeExtensions() && mediaType.getExtensions() != null) {
+            mediaType.setExtensions(new TreeMap<>(mediaType.getExtensions()));
+        }
+        return OASVisitResult.CONTINUE;
+    }
+
+    @Override
+    public OASVisitResult visit(OAuthFlow oAuthFlow, String jsonPath) {
+        if (config.getSortOAuthFlowExtensions() && oAuthFlow.getExtensions() != null) {
+            oAuthFlow.setExtensions(new TreeMap<>(oAuthFlow.getExtensions()));
+        }
+        return OASVisitResult.CONTINUE;
+    }
+
+    @Override
+    public OASVisitResult visit(OAuthFlows oAuthFlows, String jsonPath) {
+        if (config.getSortOAuthFlowsExtensions() && oAuthFlows.getExtensions() != null) {
+            oAuthFlows.setExtensions(new TreeMap<>(oAuthFlows.getExtensions()));
+        }
+        return OASVisitResult.CONTINUE;
+    }
+
+    @Override
+    public OASVisitResult visit(Operation operation, String jsonPath) {
+        if (config.getSortOperationCallbacks() && operation.getCallbacks() != null) {
+            operation.setCallbacks(new TreeMap<>(operation.getCallbacks()));
+        }
+        if (config.getSortOperationExtensions() && operation.getExtensions() != null) {
+            operation.setExtensions(new TreeMap<>(operation.getExtensions()));
+        }
+        return OASVisitResult.CONTINUE;
+    }
+
+    @Override
+    public OASVisitResult visit(Parameter parameter, String jsonPath) {
+        if (config.getSortParameterExamples() && parameter.getExamples() != null) {
+            parameter.setExamples(new TreeMap<>(parameter.getExamples()));
+        }
+        if (config.getSortParameterExtensions() && parameter.getExtensions() != null) {
+            parameter.setExtensions(new TreeMap<>(parameter.getExtensions()));
+        }
+        return OASVisitResult.CONTINUE;
+    }
+
+    @Override
+    public OASVisitResult visit(PathItem pathItem, String jsonPath) {
+        if (config.getSortPathItemExtensions() && pathItem.getExtensions() != null) {
+            pathItem.setExtensions(new TreeMap<>(pathItem.getExtensions()));
+        }
+        return OASVisitResult.CONTINUE;
+    }
+
+    @Override
+    public OASVisitResult visit(Paths paths, String jsonPath) {
+        if (config.getSortPathsPathItems() && paths.getPathItems() != null) {
+            paths.setPathItems(new TreeMap<>(paths.getPathItems()));
+        }
+        if (config.getSortPathsExtensions() && paths.getExtensions() != null) {
+            paths.setExtensions(new TreeMap<>(paths.getExtensions()));
+        }
+        return OASVisitResult.CONTINUE;
+    }
+
+    @Override
+    public OASVisitResult visit(RequestBody requestBody, String jsonPath) {
+        if (config.getSortRequestBodyExtensions() && requestBody.getExtensions() != null) {
+            requestBody.setExtensions(new TreeMap<>(requestBody.getExtensions()));
+        }
+        return OASVisitResult.CONTINUE;
+    }
+
+    @Override
+    public OASVisitResult visit(Schema schema, String jsonPath) {
+        if (config.getSortSchemaProperties() && schema.getProperties() != null) {
+            schema.setProperties(new TreeMap<>(schema.getProperties()));
+        }
+        if (config.getSortSchemaExtensions() && schema.getExtensions() != null) {
+            schema.setExtensions(new TreeMap<>(schema.getExtensions()));
+        }
+        return OASVisitResult.CONTINUE;
+    }
+
+    @Override
+    public OASVisitResult visit(Scopes scopes, String jsonPath) {
+        if (config.getSortScopesScopes() && scopes.getScopes() != null) {
+            scopes.setScopes(new TreeMap<>(scopes.getScopes()));
+        }
+        if (config.getSortScopesExtensions() && scopes.getExtensions() != null) {
+            scopes.setExtensions(new TreeMap<>(scopes.getExtensions()));
+        }
+        return OASVisitResult.CONTINUE;
+    }
+
+    @Override
+    public OASVisitResult visit(SecurityRequirement securityRequirement, String jsonPath) {
+        if (config.getSortSecurityRequirementSchemes() && securityRequirement.getSchemes() != null) {
+            securityRequirement.setSchemes(new TreeMap<>(securityRequirement.getSchemes()));
+        }
+        return OASVisitResult.CONTINUE;
+    }
+
+    @Override
+    public OASVisitResult visit(SecurityScheme securityScheme, String jsonPath) {
+        if (config.getSortSecuritySchemeExtensions() && securityScheme.getExtensions() != null) {
+            securityScheme.setExtensions(new TreeMap<>(securityScheme.getExtensions()));
+        }
+        return OASVisitResult.CONTINUE;
+    }
+
+    @Override
+    public OASVisitResult visit(Server server, String jsonPath) {
+        if (config.getSortServerExtensions() && server.getExtensions() != null) {
+            server.setExtensions(new TreeMap<>(server.getExtensions()));
+        }
+        return OASVisitResult.CONTINUE;
+    }
+
+    @Override
+    public OASVisitResult visit(ServerVariable serverVariable, String jsonPath) {
+        if (config.getSortServerVariableExtensions() && serverVariable.getExtensions() != null) {
+            serverVariable.setExtensions(new TreeMap<>(serverVariable.getExtensions()));
+        }
+        return OASVisitResult.CONTINUE;
+    }
+
+    @Override
+    public OASVisitResult visit(ServerVariables serverVariables, String jsonPath) {
+        if (config.getSortServerVariablesServerVariables() && serverVariables.getServerVariables() != null) {
+            serverVariables.setServerVariables(new TreeMap<>(serverVariables.getServerVariables()));
+        }
+        if (config.getSortServerVariablesExtensions() && serverVariables.getExtensions() != null) {
+            serverVariables.setExtensions(new TreeMap<>(serverVariables.getExtensions()));
+        }
+        return OASVisitResult.CONTINUE;
+    }
+
+    @Override
+    public OASVisitResult visit(Tag tag, String jsonPath) {
+        if (config.getSortTagExtensions() && tag.getExtensions() != null) {
+            tag.setExtensions(new TreeMap<>(tag.getExtensions()));
+        }
+        return OASVisitResult.CONTINUE;
+    }
+
+    @Override
+    public OASVisitResult visit(XML xml, String jsonPath) {
+        if (config.getSortXMLExtensions() && xml.getExtensions() != null) {
+            xml.setExtensions(new TreeMap<>(xml.getExtensions()));
+        }
+        return OASVisitResult.CONTINUE;
+    }
+
+}


### PR DESCRIPTION
In order to have stable serialization, it can be useful to sort the Maps contains in an OpenAPI instance.

New methods in `OASUtil`:

* `sortMaps(OpenAPI)` : sort all maps.
* `sortMaps(OpenAPI, SortMapsConfig)` : the `SortMapsConfig` instance allows to select which maps are sorted.